### PR TITLE
Fix typo in seed script logging

### DIFF
--- a/scripts/seedBooks.js
+++ b/scripts/seedBooks.js
@@ -95,7 +95,7 @@ const books = [
       const data = await res.json();
       console.log('הוזן:', data.title);
     } catch (error) {
-      console.error clocks(`שגיאה בהוספת ${book.title}:`, error);
+      console.error(`שגיאה בהוספת ${book.title}:`, error);
     }
   }
 })();


### PR DESCRIPTION
## Summary
- correct typo in error logging in seed script

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6841de79364c83239878f008cc5c3008