### PR TITLE
Remove Supabase remnants

### DIFF
--- a/setup-database.sh
+++ b/setup-database.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-echo "This script is deprecated. Please use Supabase migrations instead."
-echo "The database schema is now managed through Supabase migrations in the supabase/migrations directory."
+echo "This script is deprecated."
+echo "Use SQL migration files to manage the PostgreSQL schema."
 exit 1

--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -19,3 +19,14 @@ export const apiPost = async (path, body) => {
   }
   return res.json();
 };
+
+export const apiPostFormData = async (path, formData) => {
+  const res = await fetch(`${API_URL}${path}`, {
+    method: 'POST',
+    body: formData
+  });
+  if (!res.ok) {
+    throw new Error('API request failed');
+  }
+  return res.json();
+};

--- a/src/pages/admin/Categories.jsx
+++ b/src/pages/admin/Categories.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { Plus, Edit2, Trash2, ChevronRight } from 'lucide-react';
 import { apiGet, apiPost } from '../../lib/apiClient';
-const supabase = {};
 
 export default function Categories() {
   const [categories, setCategories] = useState([]);


### PR DESCRIPTION
## Summary
- drop Supabase mention from `setup-database.sh`
- add `apiPostFormData` helper for uploading FormData
- refactor `AddBook.jsx` to use API helpers instead of Supabase
- clean up `Categories.jsx`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*
- `npm run server` *(fails: cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684224d7a2008323b7e14267c665df72