### PR TITLE
Make informational pages dynamic

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -251,6 +251,34 @@ app.post('/api/categories/:id/delete', async (req, res) => {
   }
 });
 
+// ----- Site content routes -----
+app.get('/api/content/:key', async (req, res) => {
+  try {
+    const { key } = req.params;
+    const { rows } = await pool.query('SELECT value FROM site_content WHERE key=$1', [key]);
+    if (rows.length === 0) return res.json(null);
+    res.json(rows[0].value);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+app.post('/api/content/:key', async (req, res) => {
+  try {
+    const { key } = req.params;
+    const { value } = req.body;
+    await pool.query(
+      'INSERT INTO site_content(key, value) VALUES ($1,$2) ON CONFLICT(key) DO UPDATE SET value = EXCLUDED.value',
+      [key, value]
+    );
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => {
   console.log(`Server listening on port ${PORT}`);

--- a/sql/001_site_content.sql
+++ b/sql/001_site_content.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS site_content (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,14 +1,21 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { Phone, User, ShoppingCart, Search } from "lucide-react";
 import useAuthStore from '../store/authStore';
 import useCartStore from '../store/cartStore';
+import useContentStore from '../store/contentStore';
 
 export default function Header() {
   const [searchQuery, setSearchQuery] = useState("");
   const navigate = useNavigate();
   const { user, signOut } = useAuthStore();
   const { openCart, getItemsCount } = useCartStore();
+  const { getContent } = useContentStore();
+  const [phone, setPhone] = useState('');
+
+  useEffect(() => {
+    getContent('phone_number').then((val) => setPhone(val || ''));
+  }, [getContent]);
 
   const handleSearch = (e) => {
     e.preventDefault();
@@ -63,8 +70,8 @@ export default function Header() {
 
         <div className="flex items-center gap-6 text-lg">
           <div className="flex items-center gap-2 text-[#f9e79f]">
-            <Phone size={20} strokeWidth={1.5} className="rotate-90" /> 
-            <span>050-418-1216</span>
+            <Phone size={20} strokeWidth={1.5} className="rotate-90" />
+            <span>{phone}</span>
           </div>
           {user ? (
             <div className="flex items-center gap-4">

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,42 +1,18 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import useContentStore from '../store/contentStore';
 
 export default function About() {
+  const { getContent } = useContentStore();
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    getContent('about_page').then((val) => setContent(val || ''));
+  }, [getContent]);
+
   return (
     <div className="max-w-4xl mx-auto p-8">
       <h1 className="text-3xl font-bold text-[#112a55] mb-6">אודות ספרי קודש תלפיות</h1>
-      
-      <div className="bg-white rounded-xl shadow-lg p-8 space-y-6">
-        <section>
-          <h2 className="text-xl font-bold text-[#a48327] mb-3">מי אנחנו</h2>
-          <p className="text-gray-700 leading-relaxed">
-            חנות ספרי קודש תלפיות הוקמה בשנת תש"פ מתוך מטרה להנגיש ספרי קודש איכותיים במחירים הוגנים.
-            החנות שלנו מתמחה במגוון רחב של ספרי קודש, מהדורות מיוחדות, וספרי לימוד לכל הגילאים.
-          </p>
-        </section>
-
-        <section>
-          <h2 className="text-xl font-bold text-[#a48327] mb-3">המטרה שלנו</h2>
-          <p className="text-gray-700 leading-relaxed">
-            אנו שואפים להיות הכתובת המועדפת לרכישת ספרי קודש, תוך הקפדה על:
-          </p>
-          <ul className="list-disc list-inside mt-2 space-y-2 text-gray-700">
-            <li>איכות מוצרים גבוהה</li>
-            <li>שירות לקוחות מצוין</li>
-            <li>מחירים הוגנים</li>
-            <li>מבחר עשיר ומתחדש</li>
-          </ul>
-        </section>
-
-        <section>
-          <h2 className="text-xl font-bold text-[#a48327] mb-3">שירותים נוספים</h2>
-          <ul className="list-disc list-inside space-y-2 text-gray-700">
-            <li>הזמנות מיוחדות של ספרים</li>
-            <li>משלוחים לכל הארץ</li>
-            <li>כריכה ותיקון ספרים</li>
-            <li>ייעוץ מקצועי בבחירת ספרים</li>
-          </ul>
-        </section>
-      </div>
+      <div className="bg-white rounded-xl shadow-lg p-8 space-y-6" dangerouslySetInnerHTML={{ __html: content }} />
     </div>
   );
 }

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import useContentStore from '../store/contentStore';
 
 export default function Contact() {
   const [formData, setFormData] = useState({
@@ -8,6 +9,18 @@ export default function Contact() {
     message: ''
   });
   const [status, setStatus] = useState('');
+  const { getContent } = useContentStore();
+  const [contactInfo, setContactInfo] = useState({ address: '', phone: '', email: '' });
+
+  useEffect(() => {
+    Promise.all([
+      getContent('address'),
+      getContent('phone_number'),
+      getContent('contact_email')
+    ]).then(([address, phone, email]) => {
+      setContactInfo({ address: address || '', phone: phone || '', email: email || '' });
+    });
+  }, [getContent]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -36,12 +49,12 @@ export default function Contact() {
           <div className="space-y-4 text-gray-700">
             <div>
               <h3 className="font-bold">כתובת:</h3>
-              <p>רחוב הרב קוק 12, ירושלים</p>
+              <p>{contactInfo.address}</p>
             </div>
-            
+
             <div>
               <h3 className="font-bold">טלפון:</h3>
-              <p>050-418-1216</p>
+              <p>{contactInfo.phone}</p>
             </div>
             
             <div>
@@ -52,7 +65,7 @@ export default function Contact() {
             
             <div>
               <h3 className="font-bold">דוא"ל:</h3>
-              <p>info@talpiot-books.co.il</p>
+              <p>{contactInfo.email}</p>
             </div>
           </div>
         </div>

--- a/src/pages/FAQ.jsx
+++ b/src/pages/FAQ.jsx
@@ -1,28 +1,20 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import useContentStore from '../store/contentStore';
 
 export default function FAQ() {
-  const faqs = [
-    {
-      question: "מהם זמני המשלוח?",
-      answer: "משלוח רגיל: 3-5 ימי עסקים. משלוח מהיר: עד 24 שעות."
-    },
-    {
-      question: "האם יש משלוח חינם?",
-      answer: "כן, בקנייה מעל 250 ₪ המשלוח חינם."
-    },
-    {
-      question: "מה מדיניות ההחזרות?",
-      answer: "ניתן להחזיר מוצרים עד 14 יום מיום הקבלה, כל עוד המוצר במצב חדש."
-    },
-    {
-      question: "האם ניתן לאסוף עצמאית מהחנות?",
-      answer: "כן, ניתן לאסוף מהחנות בשעות הפעילות ללא עלות משלוח."
-    },
-    {
-      question: "איך ניתן ליצור קשר?",
-      answer: "ניתן ליצור קשר בטלפון 050-418-1216 או במייל info@talpiot-books.co.il"
-    }
-  ];
+  const { getContent } = useContentStore();
+  const [faqs, setFaqs] = useState([]);
+
+  useEffect(() => {
+    getContent('faq').then((val) => {
+      try {
+        const parsed = JSON.parse(val || '[]');
+        setFaqs(Array.isArray(parsed) ? parsed : []);
+      } catch {
+        setFaqs([]);
+      }
+    });
+  }, [getContent]);
 
   return (
     <div className="max-w-4xl mx-auto p-8">

--- a/src/pages/Returns.jsx
+++ b/src/pages/Returns.jsx
@@ -1,38 +1,18 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import useContentStore from '../store/contentStore';
 
 export default function Returns() {
+  const { getContent } = useContentStore();
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    getContent('returns_policy').then((val) => setContent(val || ''));
+  }, [getContent]);
+
   return (
     <div className="max-w-4xl mx-auto p-8">
       <h1 className="text-3xl font-bold text-[#112a55] mb-6">מדיניות החזרות</h1>
-      
-      <div className="bg-white rounded-xl shadow-lg p-8 space-y-6">
-        <section>
-          <h2 className="text-xl font-bold text-[#a48327] mb-3">תנאי החזרה</h2>
-          <ul className="list-disc list-inside space-y-2 text-gray-700">
-            <li>ניתן להחזיר מוצרים עד 14 יום מיום הקבלה</li>
-            <li>המוצר חייב להיות במצב חדש וללא פגיעה</li>
-            <li>יש לשמור את חשבונית הקנייה</li>
-            <li>ההחזר הכספי יבוצע באמצעי התשלום המקורי</li>
-          </ul>
-        </section>
-
-        <section>
-          <h2 className="text-xl font-bold text-[#a48327] mb-3">תהליך ההחזרה</h2>
-          <ol className="list-decimal list-inside space-y-2 text-gray-700">
-            <li>יש ליצור קשר עם שירות הלקוחות</li>
-            <li>קבלת אישור החזרה</li>
-            <li>שליחת המוצר בחזרה לחנות</li>
-            <li>בדיקת המוצר וביצוע ההחזר הכספי</li>
-          </ol>
-        </section>
-
-        <section>
-          <h2 className="text-xl font-bold text-[#a48327] mb-3">החזר כספי</h2>
-          <p className="text-gray-700 leading-relaxed">
-            ההחזר הכספי יבוצע תוך 14 ימי עסקים מיום קבלת המוצר בחנות.
-          </p>
-        </section>
-      </div>
+      <div className="bg-white rounded-xl shadow-lg p-8 space-y-6" dangerouslySetInnerHTML={{ __html: content }} />
     </div>
   );
 }

--- a/src/pages/Shipping.jsx
+++ b/src/pages/Shipping.jsx
@@ -1,37 +1,18 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import useContentStore from '../store/contentStore';
 
 export default function Shipping() {
+  const { getContent } = useContentStore();
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    getContent('shipping_policy').then((val) => setContent(val || ''));
+  }, [getContent]);
+
   return (
     <div className="max-w-4xl mx-auto p-8">
       <h1 className="text-3xl font-bold text-[#112a55] mb-6">מדיניות משלוחים</h1>
-      
-      <div className="bg-white rounded-xl shadow-lg p-8 space-y-6">
-        <section>
-          <h2 className="text-xl font-bold text-[#a48327] mb-3">זמני משלוח</h2>
-          <ul className="list-disc list-inside space-y-2 text-gray-700">
-            <li>משלוח רגיל: 3-5 ימי עסקים</li>
-            <li>משלוח מהיר: עד 24 שעות</li>
-            <li>איסוף עצמי: זמין בשעות פעילות החנות</li>
-          </ul>
-        </section>
-
-        <section>
-          <h2 className="text-xl font-bold text-[#a48327] mb-3">עלויות משלוח</h2>
-          <ul className="list-disc list-inside space-y-2 text-gray-700">
-            <li>משלוח חינם בקנייה מעל 250 ₪</li>
-            <li>משלוח רגיל: 25 ₪</li>
-            <li>משלוח מהיר: 45 ₪</li>
-            <li>איסוף עצמי: ללא עלות</li>
-          </ul>
-        </section>
-
-        <section>
-          <h2 className="text-xl font-bold text-[#a48327] mb-3">אזורי חלוקה</h2>
-          <p className="text-gray-700 leading-relaxed">
-            אנו מספקים משלוחים לכל רחבי הארץ. זמני המשלוח עשויים להשתנות בהתאם למיקום.
-          </p>
-        </section>
-      </div>
+      <div className="bg-white rounded-xl shadow-lg p-8 space-y-6" dangerouslySetInnerHTML={{ __html: content }} />
     </div>
   );
 }

--- a/src/pages/Terms.jsx
+++ b/src/pages/Terms.jsx
@@ -1,35 +1,18 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import useContentStore from '../store/contentStore';
 
 export default function Terms() {
+  const { getContent } = useContentStore();
+  const [content, setContent] = useState('');
+
+  useEffect(() => {
+    getContent('terms_page').then((val) => setContent(val || ''));
+  }, [getContent]);
+
   return (
     <div className="max-w-4xl mx-auto p-8">
       <h1 className="text-3xl font-bold text-[#112a55] mb-6">תקנון האתר</h1>
-      
-      <div className="bg-white rounded-xl shadow-lg p-8 space-y-6">
-        <section>
-          <h2 className="text-xl font-bold text-[#a48327] mb-3">כללי</h2>
-          <p className="text-gray-700 leading-relaxed">
-            תקנון זה מסדיר את תנאי השימוש באתר ספרי קודש תלפיות. השימוש באתר מהווה הסכמה לתנאים אלו.
-          </p>
-        </section>
-
-        <section>
-          <h2 className="text-xl font-bold text-[#a48327] mb-3">רכישה באתר</h2>
-          <ul className="list-disc list-inside space-y-2 text-gray-700">
-            <li>המחירים באתר כוללים מע"מ</li>
-            <li>התשלום מתבצע במעמד ההזמנה</li>
-            <li>ניתן לבטל עסקה בתוך 14 יום</li>
-            <li>הספרים נשלחים באריזה מאובטחת</li>
-          </ul>
-        </section>
-
-        <section>
-          <h2 className="text-xl font-bold text-[#a48327] mb-3">פרטיות</h2>
-          <p className="text-gray-700 leading-relaxed">
-            אנו מתחייבים לשמור על פרטיות הלקוחות ולא להעביר מידע לצד שלישי ללא הסכמה מפורשת.
-          </p>
-        </section>
-      </div>
+      <div className="bg-white rounded-xl shadow-lg p-8 space-y-6" dangerouslySetInnerHTML={{ __html: content }} />
     </div>
   );
 }

--- a/src/store/contentStore.js
+++ b/src/store/contentStore.js
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+import { apiGet, apiPost } from '../lib/apiClient';
+
+const useContentStore = create((set, get) => ({
+  values: {},
+  getContent: async (key) => {
+    if (get().values[key]) return get().values[key];
+    try {
+      const value = await apiGet(`/api/content/${key}`);
+      set(state => ({ values: { ...state.values, [key]: value } }));
+      return value;
+    } catch (error) {
+      console.error('Error loading content:', error);
+      return null;
+    }
+  },
+  updateContent: async (key, value) => {
+    try {
+      await apiPost(`/api/content/${key}`, { value });
+      set(state => ({ values: { ...state.values, [key]: value } }));
+      return { success: true };
+    } catch (error) {
+      console.error('Error updating content:', error);
+      return { success: false, error };
+    }
+  }
+}));
+
+export default useContentStore;


### PR DESCRIPTION
## Summary
- store site content in `site_content` table
- expose new `/api/content/:key` routes
- add Zustand `contentStore`
- fetch contact info, policy pages and FAQ from the database
- display dynamic phone number in header

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68454b9c51e48323a202c42bfa8b62a6