### PR TITLE
Handle book categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,16 @@ npm run server
 
 The server reads the environment variables above and listens on `PORT`.
 
-### Initializing Extra Tables
+### Initializing the Database
 
-To create optional tables for orders, promotions and other admin features run:
+To create the tables required by the API (books, categories and other admin features) run:
 
 ```bash
 curl -X POST http://localhost:3000/api/setup
 ```
 
-This route creates the `orders`, `order_items`, `promotions`, `email_subscribers`,
-`settings` and `statistics` tables if they do not exist.
+This route creates the `books`, `categories`, `book_categories`, `orders`, `order_items`,
+`promotions`, `email_subscribers`, `settings` and `statistics` tables if they do not exist.
 
 ## Building and Serving the React Frontend
 


### PR DESCRIPTION
## Summary
- support setting categories when creating or updating books
- create tables for books, categories and book_categories in `/api/setup`
- document new setup steps

## Testing
- `npm run server` *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68455b5c87bc832389dccf0ad477b78b