### PR TITLE
Fix request size limit error

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -8,7 +8,9 @@ const { Pool } = pkg;
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
 const app = express();
-app.use(express.json());
+// Increase payload limits to allow larger JSON bodies
+app.use(express.json({ limit: '10mb' }));
+app.use(express.urlencoded({ extended: true, limit: '10mb' }));
 
 // Get books with optional search and filter parameters
 app.get('/api/books', async (req, res) => {


### PR DESCRIPTION
## Summary
- allow up to 10MB JSON and URL encoded payloads in Express server

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6845deb4ce3c8323b568cd2430985e9b