### PR TITLE
Fix all remaining API links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 DATABASE_URL=postgres://user:password@localhost:5432/booksdb
 # Express server port. Use a value other than 3000 if running the Vite dev server.
 PORT=3001
+VITE_API_URL=https://api.talpiot-books.com

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Create a `.env` file (you can copy `.env.example`) and set the following variabl
 
 - `DATABASE_URL` – PostgreSQL connection string used by the API server.
 - `PORT` – Port for the Express server (defaults to `3000` if not set).
+- `VITE_API_URL` – Base URL for the API when running the frontend (e.g. `https://api.talpiot-books.com`).
 
 The Vite development server also listens on port `3000`. If you plan to run the
 API server and frontend simultaneously, set `PORT` to a different value (for
@@ -36,7 +37,7 @@ The server reads the environment variables above and listens on `PORT`.
 To create the tables required by the API (books, categories and other admin features) run:
 
 ```bash
-curl -X POST http://localhost:3000/api/setup
+curl -X POST https://api.talpiot-books.com/api/setup
 ```
 
 This route creates the `books`, `categories`, `book_categories`, `orders`, `order_items`,
@@ -72,6 +73,7 @@ This serves the content of the `dist` directory on the port configured in `vite.
 2. ערכו את הערכים:
    - `DATABASE_URL` – כתובת החיבור למסד הנתונים PostgreSQL.
    - `PORT` – מספר הפורט שעליו ירוץ שרת Express (ברירת מחדל 3000). אם אתם מפעילים גם את שרת Vite במקביל, מומלץ לבחור פורט אחר (למשל 3001).
+   - `VITE_API_URL` – כתובת הבסיס ל־API בעת הרצת הפרונטאנד (לדוגמה `https://api.talpiot-books.com`).
 
 ### התקנת חבילות
 

--- a/scripts/seedBooks.js
+++ b/scripts/seedBooks.js
@@ -86,7 +86,7 @@ const books = [
 (async () => {
   for (const book of books) {
     try {
-      const res = await fetch('http://sr.70-60.com:3010/api/books', {
+      const res = await fetch('https://api.talpiot-books.com/api/books', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(book)

--- a/src/pages/BookDetails.js
+++ b/src/pages/BookDetails.js
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from "react";
-import axios from "axios";
+import { apiGet } from "../lib/apiClient";
 import { useParams, Link } from "react-router-dom";
 
-const API_BASE = "http://sr.70-60.com:3010";
+const API_BASE = import.meta.env.VITE_API_URL || "";
 
 export default function BookDetails() {
   const { id } = useParams();
@@ -14,8 +14,8 @@ export default function BookDetails() {
     const fetchBook = async () => {
       try {
         setLoading(true);
-        const res = await axios.get(`${API_BASE}/api/books/${id}`);
-        setBook(res.data);
+        const data = await apiGet(`/api/books/${id}`);
+        setBook(data);
       } catch (err) {
         setError("שגיאה בטעינת הספר");
         console.error("שגיאה בשליפת ספר:", err);


### PR DESCRIPTION
## Summary
- replace setup endpoint in README with new domain
- add API URL env variable to docs and example file
- fetch book details using apiClient with configurable base URL

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845f10456f08323bfd9c266238ae639