### PR TITLE
Add CORS support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 DATABASE_URL=postgres://user:password@localhost:5432/booksdb
 # Express server port. Use a value other than 3000 if running the Vite dev server.
 PORT=3001
+# Allow frontend origin for CORS (e.g., https://talpiot-books.com)
+CORS_ORIGIN=

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "express": "^4.18.2",
     "pg": "^8.11.1",
     "node-fetch": "^2.6.9",
-    "dotenv": "^16.3.1"
+    "dotenv": "^16.3.1",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "@types/react": "^18.2.43",

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import pkg from 'pg';
 import dotenv from 'dotenv';
+import cors from 'cors';
 
 dotenv.config();
 
@@ -8,6 +9,7 @@ const { Pool } = pkg;
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
 const app = express();
+app.use(cors({ origin: process.env.CORS_ORIGIN || '*' }));
 // Increase payload limits to allow larger JSON bodies
 app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true, limit: '10mb' }));


### PR DESCRIPTION
## Summary
- enable CORS using express middleware
- document `CORS_ORIGIN` in `.env.example`
- add cors dependency

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: 403 Forbidden for cors)*

------
https://chatgpt.com/codex/tasks/task_e_6846a278dc1483239c0114c55ca9e569