### PR TITLE
Fix missing site_content table creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ curl -X POST http://localhost:3000/api/setup
 ```
 
 This route creates the `books`, `categories`, `book_categories`, `orders`, `order_items`,
-`promotions`, `email_subscribers`, `settings` and `statistics` tables if they do not exist.
+`promotions`, `email_subscribers`, `settings`, `statistics` and `site_content` tables if they do not exist.
 
 ## Building and Serving the React Frontend
 

--- a/server/index.js
+++ b/server/index.js
@@ -522,6 +522,10 @@ app.post('/api/content/:key', async (req, res) => {
 // ----- Setup route -----
 app.post('/api/setup', async (req, res) => {
   try {
+    await pool.query(`CREATE TABLE IF NOT EXISTS site_content (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    )`);
     await pool.query(`CREATE TABLE IF NOT EXISTS categories (
       id SERIAL PRIMARY KEY,
       name TEXT NOT NULL,


### PR DESCRIPTION
## Summary
- create `site_content` table in the `/api/setup` route
- document `site_content` table in database setup instructions

## Testing
- `node --check server/index.js`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846aeea32bc83239e80905348dbbbee