### PR TITLE
Add contact buttons and popup

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { Phone, User, ShoppingCart, Search } from "lucide-react";
+import { Phone, User, ShoppingCart, Search, MessageCircle, Grid, X } from "lucide-react";
 import useAuthStore from '../store/authStore';
 import useCartStore from '../store/cartStore';
 import useContentStore from '../store/contentStore';
@@ -12,6 +12,7 @@ export default function Header() {
   const { openCart, getItemsCount } = useCartStore();
   const { getContent } = useContentStore();
   const [phone, setPhone] = useState('');
+  const [showContactPopup, setShowContactPopup] = useState(false);
 
   useEffect(() => {
     getContent('phone_number').then((val) => setPhone(val || ''));
@@ -22,6 +23,10 @@ export default function Header() {
     if (searchQuery.trim()) {
       navigate(`/?search=${encodeURIComponent(searchQuery)}`);
     }
+  };
+
+  const handleWhatsApp = () => {
+    window.open('https://wa.me/972504181216', '_blank');
   };
 
   return (
@@ -40,15 +45,39 @@ export default function Header() {
       </div>
 
       <div className="py-6 px-6">
-        <Link to="/" className="flex flex-col justify-center items-center gap-2">
-          <img 
-            src="/logo.png" 
-            alt="ספרי קודש תלפיות" 
-            className="h-48 object-contain"
-            style={{ filter: 'brightness(0.85)' }}
-          />
-          <p className="text-[#112a55] text-2xl font-bold tracking-wide" style={{ fontFamily: 'Frank Ruhl Libre, serif' }}>המקום המושלם לספרי קודש במחירים נוחים</p>
-        </Link>
+        <div className="flex flex-col items-center gap-6">
+          <Link to="/" className="flex flex-col justify-center items-center gap-2">
+            <img
+              src="/logo.png"
+              alt="ספרי קודש תלפיות"
+              className="h-48 object-contain"
+              style={{ filter: 'brightness(0.85)' }}
+            />
+            <p className="text-[#112a55] text-2xl font-bold tracking-wide" style={{ fontFamily: 'Frank Ruhl Libre, serif' }}>המקום המושלם לספרי קודש במחירים נוחים</p>
+          </Link>
+
+          <div className="flex gap-8 items-center">
+            <div className="flex flex-col items-center gap-2">
+              <button
+                onClick={() => setShowContactPopup(true)}
+                className="w-16 h-16 bg-[#112a55] rounded-full flex items-center justify-center shadow-lg hover:bg-[#1a3c70] transition-colors"
+              >
+                <MessageCircle size={32} className="text-white" />
+              </button>
+              <span className="text-[#a48327]">יצירת קשר</span>
+            </div>
+
+            <div className="flex flex-col items-center gap-2">
+              <Link
+                to="/categories"
+                className="w-16 h-16 bg-[#112a55] rounded-full flex items-center justify-center shadow-lg hover:bg-[#1a3c70] transition-colors"
+              >
+                <Grid size={32} className="text-white" />
+              </Link>
+              <span className="text-[#a48327]">כל הקטגוריות</span>
+            </div>
+          </div>
+        </div>
       </div>
 
       <div className="bg-[#112a55] text-white px-6 py-4 flex flex-col lg:flex-row justify-between items-center gap-4">
@@ -99,6 +128,44 @@ export default function Header() {
           </button>
         </div>
       </div>
+
+      {showContactPopup && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50">
+          <div className="bg-white rounded-2xl p-6 max-w-sm w-full relative">
+            <button
+              onClick={() => setShowContactPopup(false)}
+              className="absolute left-4 top-4 text-gray-500 hover:text-gray-700"
+            >
+              <X size={24} />
+            </button>
+
+            <h2 className="text-2xl font-bold text-[#112a55] mb-6">יצירת קשר</h2>
+
+            <div className="space-y-4">
+              <button
+                onClick={handleWhatsApp}
+                className="w-full bg-green-500 text-white py-3 rounded-lg hover:bg-green-600 transition-colors flex items-center justify-center gap-2"
+              >
+                <MessageCircle size={24} />
+                <span>שלח הודעת WhatsApp</span>
+              </button>
+
+              <Link
+                to="/contact"
+                onClick={() => setShowContactPopup(false)}
+                className="w-full bg-[#112a55] text-white py-3 rounded-lg hover:bg-[#1a3c70] transition-colors flex items-center justify-center"
+              >
+                השאר הודעה
+              </Link>
+
+              <p className="text-center text-gray-500 text-sm">
+                אנו מתחייבים לחזור אליך תוך יום עסקים אחד
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- add WhatsApp/contact buttons under the logo
- display popup with WhatsApp link and contact form

## Testing
- `npm test` *(fails: Missing script)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6846daeecc2083238495f3a97eb86251