### PR TITLE
Ensure images display without cropping

### DIFF
--- a/src/components/Catalog.jsx
+++ b/src/components/Catalog.jsx
@@ -41,7 +41,7 @@ export default function Catalog() {
               <img
                 src={`https://via.placeholder.com/300x400.png?text=${encodeURIComponent(book.title)}`}
                 alt={book.title}
-                className="w-full h-64 object-cover rounded-t-2xl"
+                className="w-full h-[300px] object-contain bg-white rounded-t-2xl"
               />
             )}
 

--- a/src/components/CategoriesView.jsx
+++ b/src/components/CategoriesView.jsx
@@ -44,7 +44,7 @@ function CategoryBooks({ books, categoryName, onClose }) {
                   <img
                     src={book.image_url || `https://via.placeholder.com/100x150.png?text=${encodeURIComponent(book.title)}`}
                     alt={book.title}
-                    className="w-24 h-32 object-cover rounded"
+                    className="w-24 h-32 object-contain bg-white rounded"
                   />
                   <div>
                     <h4 className="font-bold text-[#112a55]">{book.title}</h4>
@@ -180,7 +180,7 @@ export default function CategoriesView() {
                 <img
                   src={book.image_url || `https://via.placeholder.com/100x150.png?text=${encodeURIComponent(book.title)}`}
                   alt={book.title}
-                  className="w-24 h-32 object-cover rounded"
+                  className="w-24 h-32 object-contain bg-white rounded"
                 />
                 <div>
                   <h3 className="font-bold text-[#112a55]">{book.title}</h3>

--- a/src/components/NewInMarket.jsx
+++ b/src/components/NewInMarket.jsx
@@ -50,7 +50,7 @@ export const NewInMarket = () => {
               <img
                 src={book.image_url ? book.image_url : `https://via.placeholder.com/300x400.png?text=${encodeURIComponent(book.title)}`}
                 alt={book.title}
-                className="w-full h-32 object-cover rounded-lg shadow group-hover:opacity-90 transition-opacity"
+                className="w-full h-32 object-contain bg-white rounded-lg shadow group-hover:opacity-90 transition-opacity"
               />
               <p className="text-center mt-3 font-serif text-lg text-[#2c1810]">{book.title}</p>
               <p className="text-center text-[#8b6f1f] font-bold mt-1">{book.price} ₪</p>

--- a/src/components/NewOnSite.jsx
+++ b/src/components/NewOnSite.jsx
@@ -122,7 +122,7 @@ export const NewOnSite = () => {
               <img
                 src={book.image_url || `https://via.placeholder.com/300x400.png?text=${encodeURIComponent(book.title)}`}
                 alt={book.title}
-                className="w-full h-32 object-cover rounded-lg shadow group-hover:opacity-90 transition-opacity"
+                className="w-full h-32 object-contain bg-white rounded-lg shadow group-hover:opacity-90 transition-opacity"
               />
               <p className="text-center mt-3 font-serif text-lg text-[#2c1810]">{book.title}</p>
               <p className="text-center text-[#8b6f1f] font-bold mt-1">{book.price} ₪</p>

--- a/src/components/PromoBoxes.jsx
+++ b/src/components/PromoBoxes.jsx
@@ -10,7 +10,7 @@ export default function PromoBoxes() {
           <img 
             src="https://images.pexels.com/photos/159866/books-book-pages-read-literature-159866.jpeg" 
             alt="מבצע מיוחד"
-            className="w-full h-full object-cover"
+            className="w-full h-full object-contain"
           />
           <div className="absolute inset-0 bg-gradient-to-t from-black/70 to-transparent flex items-end p-6">
             <div className="text-white">
@@ -38,7 +38,7 @@ export default function PromoBoxes() {
           <img 
             src="https://images.pexels.com/photos/2041540/pexels-photo-2041540.jpeg" 
             alt="ספרים חדשים"
-            className="w-full h-full object-cover"
+            className="w-full h-full object-contain"
           />
           <div className="absolute inset-0 bg-gradient-to-t from-black/70 to-transparent flex items-end p-6">
             <div className="text-white">

--- a/src/components/ShoppingCart.jsx
+++ b/src/components/ShoppingCart.jsx
@@ -43,7 +43,7 @@ export default function ShoppingCart() {
                 <img
                   src={item.image_url || `https://via.placeholder.com/100x150.png?text=${encodeURIComponent(item.title)}`}
                   alt={item.title}
-                  className="w-20 h-28 object-cover rounded"
+                  className="w-20 h-28 object-contain bg-white rounded"
                 />
                 <div className="flex-1">
                   <div className="flex justify-between">

--- a/src/pages/Checkout.jsx
+++ b/src/pages/Checkout.jsx
@@ -198,7 +198,7 @@ export default function Checkout() {
                 <img
                   src={item.image_url || `https://via.placeholder.com/100x150.png?text=${encodeURIComponent(item.title)}`}
                   alt={item.title}
-                  className="w-20 h-28 object-cover rounded"
+                  className="w-20 h-28 object-contain bg-white rounded"
                 />
                 <div className="flex-1">
                   <h3 className="font-bold text-[#112a55]">{item.title}</h3>


### PR DESCRIPTION
## Summary
- keep catalog placeholder images contained
- avoid cropping in categories and new books sections
- ensure promo, cart, and checkout images fit containers

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473ce208008323938f6b419de40f0d