### PR TITLE
Add image compression for book uploads

### DIFF
--- a/src/lib/imageUtils.js
+++ b/src/lib/imageUtils.js
@@ -1,0 +1,38 @@
+export async function compressImage(file, maxSizeMB = 5) {
+  if (!file) return file;
+  if (file.size <= maxSizeMB * 1024 * 1024) {
+    return file;
+  }
+
+  const image = new Image();
+  const objectUrl = URL.createObjectURL(file);
+  image.src = objectUrl;
+  await new Promise((resolve, reject) => {
+    image.onload = () => resolve();
+    image.onerror = reject;
+  });
+
+  const canvas = document.createElement('canvas');
+  let scale = Math.sqrt((maxSizeMB * 1024 * 1024) / file.size);
+  if (scale > 1) scale = 1;
+  canvas.width = image.width * scale;
+  canvas.height = image.height * scale;
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
+
+  let quality = 0.92;
+  let blob = await new Promise((resolve) =>
+    canvas.toBlob(resolve, 'image/jpeg', quality)
+  );
+  while (blob && blob.size > maxSizeMB * 1024 * 1024 && quality > 0.5) {
+    quality -= 0.05;
+    blob = await new Promise((resolve) =>
+      canvas.toBlob(resolve, 'image/jpeg', quality)
+    );
+  }
+
+  URL.revokeObjectURL(objectUrl);
+  return new File([blob], file.name.replace(/\.[^.]+$/, '.jpg'), {
+    type: 'image/jpeg',
+  });
+}

--- a/src/pages/admin/AddBook.jsx
+++ b/src/pages/admin/AddBook.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Upload, ArrowRight, Loader, Plus } from 'lucide-react';
 import { apiPostFormData } from '../../lib/apiClient';
+import { compressImage } from '../../lib/imageUtils';
 import useCategoriesStore from '../../store/categoriesStore';
 import useBooksStore from '../../store/booksStore';
 
@@ -20,6 +21,12 @@ export default function AddBook() {
     console.log('Initializing categories');
     initCategories();
   }, [initCategories]);
+
+  useEffect(() => {
+    if (mode === 'ai' && step === 2 && categories.length === 0) {
+      initCategories();
+    }
+  }, [mode, step, categories.length, initCategories]);
   const [bookData, setBookData] = useState({
     title: '',
     author: '',
@@ -42,9 +49,10 @@ export default function AddBook() {
     const file = e.target.files[0];
     if (!file) return;
 
-    setImageFile(file);
-    setImagePreview(URL.createObjectURL(file));
-    console.log('Selected image for upload', file);
+    const compressed = await compressImage(file);
+    setImageFile(compressed);
+    setImagePreview(URL.createObjectURL(compressed));
+    console.log('Selected image for upload', compressed);
 
     if (mode === 'ai') {
       setLoading(true);
@@ -82,12 +90,12 @@ export default function AddBook() {
       let imageUrl = bookData.image_url;
 
       if (imageFile) {
-        // Placeholder: convert image to base64 string for now
+        const finalFile = await compressImage(imageFile);
         const reader = new FileReader();
         imageUrl = await new Promise((resolve, reject) => {
           reader.onload = () => resolve(reader.result);
           reader.onerror = reject;
-          reader.readAsDataURL(imageFile);
+          reader.readAsDataURL(finalFile);
         });
       }
 


### PR DESCRIPTION
## Summary
- add helper to compress images under 5MB
- use the helper when selecting and uploading book images
- reload categories when needed

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f7c1726c8323b44862261295920b