### PR TITLE
Conditionally disable image analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ Create a `.env` file (you can copy `.env.example`) and set the following variabl
 - `DATABASE_URL` – PostgreSQL connection string used by the API server.
 - `PORT` – Port for the Express server (defaults to `3000` if not set).
 - `OPENAI_API_KEY` – API key with access to GPT‑4 Vision used to extract book
-  details directly from uploaded cover images.
+  details directly from uploaded cover images. If omitted, the `/api/analyze-book-image`
+  endpoint will return a `503` response and book image analysis will be disabled.
 
 The Vite development server also listens on port `3000`. If you plan to run the
 API server and frontend simultaneously, set `PORT` to a different value (for

--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,12 @@ import setupRouter from './router/setup.js';
 
 dotenv.config();
 
+if (!process.env.OPENAI_API_KEY) {
+  console.warn(
+    'OPENAI_API_KEY not set. /api/analyze-book-image endpoint is disabled.'
+  );
+}
+
 const app = express();
 const corsOptions = { origin: process.env.CORS_ORIGIN || '*' };
 app.use(cors(corsOptions));


### PR DESCRIPTION
## Summary
- warn when OPENAI_API_KEY isn't defined at server startup
- load dotenv in analyze router and only create OpenAI client if a key exists
- return HTTP 503 from `/api/analyze-book-image` when not configured
- document the disabled behavior in README

## Testing
- `npm install` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_684802bb3f1083238128fecdd2e08e3e