### PR TITLE
Use bcrypt for password hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Install the JavaScript dependencies for both the frontend and server:
 npm install
 ```
 
+This will also install the new `bcrypt` package used to securely hash user
+passwords on registration.
+
 ## Running the Express Server
 
 Start the API server with:
@@ -85,6 +88,8 @@ This serves the content of the `dist` directory on the port configured in `vite.
 ```bash
 npm install
 ```
+
+הפקודה תתקין גם את החבילה `bcrypt` המשמשת להצפנת סיסמאות משתמשים.
 
 ### הפעלת שרת Express
 

--- a/package.json
+++ b/package.json
@@ -11,19 +11,20 @@
   },
   "dependencies": {
     "axios": "^1.6.7",
+    "bcrypt": "^5.1.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
+    "express": "^4.18.2",
     "lucide-react": "^0.486.0",
+    "multer": "^1.4.5-lts.1",
+    "node-fetch": "^2.6.9",
+    "openai": "^4.0.0",
+    "pg": "^8.11.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.0",
     "recharts": "^2.12.3",
-    "zustand": "^4.5.0",
-    "openai": "^4.0.0",
-    "multer": "^1.4.5-lts.1",
-    "express": "^4.18.2",
-    "pg": "^8.11.1",
-    "node-fetch": "^2.6.9",
-    "dotenv": "^16.3.1",
-    "cors": "^2.8.5"
+    "zustand": "^4.5.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.43",

--- a/server/router/auth.js
+++ b/server/router/auth.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import crypto from 'crypto';
+import bcrypt from 'bcrypt';
 import pool from '../db.js';
 
 export const sessions = {};
@@ -42,9 +43,10 @@ router.post('/api/auth/register', async (req, res) => {
       return res.status(400).json({ error: 'User already exists' });
     }
 
+    const hashed = await bcrypt.hash(password, 10);
     const { rows } = await pool.query(
       'INSERT INTO users (email, password) VALUES ($1,$2) RETURNING id, email',
-      [email, password]
+      [email, hashed]
     );
     const user = rows[0];
 
@@ -62,15 +64,19 @@ router.post('/api/auth/login', async (req, res) => {
   try {
     const { email, password } = req.body;
     const { rows } = await pool.query(
-      'SELECT id, email FROM users WHERE email=$1 AND password=$2',
-      [email, password]
+      'SELECT id, email, password FROM users WHERE email=$1',
+      [email]
     );
     const user = rows[0];
     if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+
+    const ok = await bcrypt.compare(password, user.password);
+    if (!ok) return res.status(401).json({ error: 'Invalid credentials' });
+
     const sid = crypto.randomUUID();
     sessions[sid] = user.id;
     res.cookie('session_id', sid, { httpOnly: true });
-    res.json({ user });
+    res.json({ user: { id: user.id, email: user.email } });
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Database error' });


### PR DESCRIPTION
## Summary
- add bcrypt to dependencies
- hash passwords on registration
- compare password hashes on login
- document bcrypt installation in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482a5acd4883239b9fbc1d37bf71e8