### PR TITLE
Handle missing OpenAI key

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,12 @@ import setupRouter from './router/setup.js';
 
 dotenv.config();
 
+if (!process.env.OPENAI_API_KEY) {
+  console.warn(
+    'OPENAI_API_KEY is not set. /api/analyze-book-image endpoint will be disabled.'
+  );
+}
+
 const app = express();
 const corsOptions = { origin: process.env.CORS_ORIGIN || '*' };
 app.use(cors(corsOptions));

--- a/server/router/analyze.js
+++ b/server/router/analyze.js
@@ -3,12 +3,24 @@ import OpenAI from 'openai';
 
 const router = express.Router();
 
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+let openai;
+if (process.env.OPENAI_API_KEY) {
+  openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+} else {
+  console.warn(
+    'OPENAI_API_KEY is not configured. /api/analyze-book-image will be disabled.'
+  );
+}
 
 router.post(
   '/api/analyze-book-image',
   express.raw({ type: 'multipart/form-data', limit: '10mb' }),
   async (req, res) => {
+    if (!openai) {
+      return res.status(503).json({
+        error: 'Image analysis feature inactive: missing OPENAI_API_KEY',
+      });
+    }
     try {
       const boundaryMatch = req.headers['content-type']?.match(/boundary=(.*)$/);
       if (!boundaryMatch) {


### PR DESCRIPTION
## Summary
- warn when `OPENAI_API_KEY` is missing
- skip OpenAI client setup if key isn't configured
- return 503 from `/api/analyze-book-image` when feature disabled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68482a5a6fe083239c95ce5c0e1fd218