### PR TITLE
Fix CORS for credentialed requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,5 +3,7 @@ DATABASE_URL=postgres://user:password@localhost:5432/booksdb
 PORT=3001
 # Allow frontend origin for CORS (e.g., https://talpiot-books.com)
 CORS_ORIGIN=
+# Base URL of the API used by the frontend
+VITE_API_URL=http://localhost:3001
 # API key with access to GPT-4 Vision used in /api/analyze-book-image
 OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Create a `.env` file (you can copy `.env.example`) and set the following variabl
 - `OPENAI_API_KEY` – API key with access to GPT‑4 Vision used to extract book
   details directly from uploaded cover images. If omitted, the `/api/analyze-book-image`
   endpoint will return a `503` response and book image analysis will be disabled.
+- `CORS_ORIGIN` – Frontend origin allowed to access the API. Set this to the URL
+  where the React app is hosted (e.g. `https://talpiot-books.com`).
+- `VITE_API_URL` – Base URL of the API used by the frontend. In production this
+  should match the public address of the Express server (e.g.
+  `https://api.talpiot-books.com`).
 
 The Vite development server also listens on port `3000`. If you plan to run the
 API server and frontend simultaneously, set `PORT` to a different value (for

--- a/server/index.js
+++ b/server/index.js
@@ -21,7 +21,10 @@ if (!process.env.OPENAI_API_KEY) {
 }
 
 const app = express();
-const corsOptions = { origin: process.env.CORS_ORIGIN || '*' };
+const corsOptions = {
+  origin: process.env.CORS_ORIGIN || '*',
+  credentials: true
+};
 app.use(cors(corsOptions));
 app.options('*', cors(corsOptions));
 app.use(express.json({ limit: '10mb' }));

--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -19,13 +19,16 @@ async function handleResponse(res) {
 }
 
 export const apiGet = async (path) => {
-  const res = await fetch(`${API_URL}${path}`);
+  const res = await fetch(`${API_URL}${path}`, {
+    credentials: 'include'
+  });
   return handleResponse(res);
 };
 
 export const apiPost = async (path, body) => {
   const res = await fetch(`${API_URL}${path}`, {
     method: 'POST',
+    credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body)
   });
@@ -35,6 +38,7 @@ export const apiPost = async (path, body) => {
 export const apiPostFormData = async (path, formData) => {
   const res = await fetch(`${API_URL}${path}`, {
     method: 'POST',
+    credentials: 'include',
     body: formData
   });
   return handleResponse(res);


### PR DESCRIPTION
## Summary
- allow credentials in server CORS config
- send cookies with API requests
- document new environment variables for CORS
- show `VITE_API_URL` in env example

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6873cb1f6b0c8323aa8d4b548e78b8da