### PR TITLE
feat: enforce JSON output for book image analysis

### DIFF
--- a/server/router/analyze.js
+++ b/server/router/analyze.js
@@ -63,6 +63,7 @@ router.post(
         model: 'gpt-4o',
         messages,
         temperature: 0,
+        response_format: { type: 'json_object' },
       });
       let metadata = { title: '', author: '', description: '', isbn: '' };
       try {


### PR DESCRIPTION
## Summary
- ensure `/api/analyze-book-image` receives responses formatted as JSON

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6890cdd2c4688323aa2f33141daf522a