### PR TITLE
feat: display book catalog on home page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,6 @@
 import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
 import { useEffect, useState } from "react";
-import Catalog from "./components/Catalog";
 import Header from "./components/Header";
-import PromoBoxes from "./components/PromoBoxes";
-import { NewOnSite } from './components/NewOnSite';
-import { NewInMarket } from './components/NewInMarket';
 import Home from './pages/Home';
 import CategoriesView from "./components/CategoriesView";
 import BookDetails from "./components/BookDetails";

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PromoBoxes from '../components/PromoBoxes';
 import { NewOnSite } from '../components/NewOnSite';
 import { NewInMarket } from '../components/NewInMarket';
+import Catalog from '../components/Catalog';
 
 export default function Home() {
   return (
@@ -17,6 +18,7 @@ export default function Home() {
 
       <NewOnSite />
       <NewInMarket />
+      <Catalog />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- show the full book catalog on the homepage for easier browsing
- remove leftover catalog imports from App to keep routing clean

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890cf6f3d788323bc574fc64765c736