### PR TITLE
Fix AI image upload in AddBook

### DIFF
--- a/src/pages/admin/AddBook.jsx
+++ b/src/pages/admin/AddBook.jsx
@@ -49,16 +49,22 @@ export default function AddBook() {
     const file = e.target.files[0];
     if (!file) return;
 
-    const compressed = await compressImage(file);
-    setImageFile(compressed);
-    setImagePreview(URL.createObjectURL(compressed));
-    console.log('Selected image for upload', compressed);
+    let processedFile = file;
+    try {
+      processedFile = await compressImage(file);
+    } catch (err) {
+      console.error('Error compressing image:', err);
+    }
+
+    setImageFile(processedFile);
+    setImagePreview(URL.createObjectURL(processedFile));
+    console.log('Selected image for upload', processedFile);
 
     if (mode === 'ai') {
       setLoading(true);
       try {
         const formData = new FormData();
-        formData.append('image', file);
+        formData.append('image', processedFile);
 
         const aiResponse = await apiPostFormData('/api/analyze-book-image', formData);
         console.log('AI response', aiResponse);


### PR DESCRIPTION
## Summary
- use compressed image for AI analysis to avoid blank page
- add error handling around compression

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891079437e08323b5dcfc8ab071d0e6