### PR TITLE
feat: support multiple categories per book

### DIFF
--- a/src/components/BookDetails.jsx
+++ b/src/components/BookDetails.jsx
@@ -13,7 +13,7 @@ export default function BookDetails() {
   const relatedBooks = useMemo(() => {
     if (!book) return [];
     return books
-      .filter(b => b.category === book.category && b.id !== book.id)
+      .filter(b => b.id !== book.id && b.categories?.some(cat => book.categories?.includes(cat)))
       .slice(0, 4);
   }, [books, book]);
 
@@ -44,11 +44,13 @@ export default function BookDetails() {
             <div>
               <h1 className="text-3xl font-bold text-[#112a55] mb-2">{book.title}</h1>
               <p className="text-xl text-gray-600 mb-4">{book.author || "מחבר לא ידוע"}</p>
-              <div className="flex items-center gap-2 text-[#a48327]">
-                <span className="text-sm bg-[#fdf6ec] px-3 py-1 rounded-full">
-                  {book.category}
-                </span>
-              </div>
+                <div className="flex items-center gap-2 flex-wrap text-[#a48327]">
+                  {book.categories?.map(cat => (
+                    <span key={cat} className="text-sm bg-[#fdf6ec] px-3 py-1 rounded-full">
+                      {cat}
+                    </span>
+                  ))}
+                </div>
             </div>
 
             <p className="text-gray-700 text-lg leading-relaxed border-t border-b border-gray-100 py-4">

--- a/src/components/CategoriesView.jsx
+++ b/src/components/CategoriesView.jsx
@@ -125,10 +125,10 @@ export default function CategoriesView() {
 
   useEffect(() => {
     if (searchQuery) {
-      const filtered = books.filter(book => 
+      const filtered = books.filter(book =>
         book.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
         book.author?.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        book.category?.toLowerCase().includes(searchQuery.toLowerCase())
+        book.categories?.some(cat => cat.toLowerCase().includes(searchQuery.toLowerCase()))
       );
       setFilteredBooks(filtered);
     } else {
@@ -137,8 +137,8 @@ export default function CategoriesView() {
   }, [searchQuery, books]);
 
   const handleViewBooks = (categoryName) => {
-    const categoryBooks = books.filter(book => 
-      book.category?.toLowerCase() === categoryName.toLowerCase()
+    const categoryBooks = books.filter(book =>
+      book.categories?.some(cat => cat.toLowerCase() === categoryName.toLowerCase())
     );
     setSelectedCategory({ name: categoryName, books: categoryBooks });
   };

--- a/src/pages/AdminBookManager.js
+++ b/src/pages/AdminBookManager.js
@@ -12,7 +12,7 @@ export default function AdminBookManager() {
     price: "",
     availability: "available",
     image_url: "",
-    category: ""
+    categories: []
   });
   const [searchQuery, setSearchQuery] = useState("");
   const [message, setMessage] = useState("");
@@ -40,7 +40,7 @@ export default function AdminBookManager() {
           price: "",
           availability: "available",
           image_url: "",
-          category: ""
+          categories: []
         });
       } else {
         throw result.error;
@@ -57,6 +57,9 @@ export default function AdminBookManager() {
   };
 
   const handleEdit = (book) => {
+    const selected = categories
+      .filter(cat => book.categories?.includes(cat.name))
+      .map(cat => cat.id);
     setFormData({
       id: book.id,
       title: book.title || "",
@@ -65,7 +68,7 @@ export default function AdminBookManager() {
       price: book.price?.toString() || "",
       availability: book.availability || "available",
       image_url: book.image_url || "",
-      category: book.category || ""
+      categories: selected
     });
   };
 
@@ -165,17 +168,28 @@ export default function AdminBookManager() {
           className="w-full border px-3 py-2 rounded"
         />
 
-        <select
-          name="category"
-          value={formData.category}
-          onChange={handleChange}
-          className="w-full border px-3 py-2 rounded"
-        >
-          <option value="">בחר קטגוריה</option>
-          {categories.map(cat => (
-            <option key={cat.id} value={cat.id}>{cat.name}</option>
-          ))}
-        </select>
+        <div>
+          <label className="block text-gray-700 mb-1">קטגוריות</label>
+          <div className="grid grid-cols-2 gap-2 max-h-48 overflow-y-auto border p-2 rounded">
+            {categories.map(cat => (
+              <label key={cat.id} className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={formData.categories.includes(cat.id)}
+                  onChange={(e) => {
+                    if (e.target.checked) {
+                      setFormData(prev => ({ ...prev, categories: [...prev.categories, cat.id] }));
+                    } else {
+                      setFormData(prev => ({ ...prev, categories: prev.categories.filter(id => id !== cat.id) }));
+                    }
+                  }}
+                  className="form-checkbox h-5 w-5 text-[#112a55]"
+                />
+                <span>{cat.name}</span>
+              </label>
+            ))}
+          </div>
+        </div>
 
         <button
           type="submit"

--- a/src/pages/admin/Products.jsx
+++ b/src/pages/admin/Products.jsx
@@ -19,37 +19,37 @@ export default function Products() {
   const [validationErrors, setValidationErrors] = useState({});
   const [imagePreview, setImagePreview] = useState('');
 
-  const [formData, setFormData] = useState({
-    title: '',
-    author: '',
-    description: '',
-    price: '',
-    category: '',
-    image_url: '',
-    availability: 'available',
-    isbn: '',
-    publisher: '',
-    publication_year: '',
-    pages: '',
-    language: 'hebrew',
-    binding: 'hardcover',
-    dimensions: '',
-    weight: '',
-    stock: '1',
-    is_new_arrival: false,
-    is_new_in_market: false
-  });
+    const [formData, setFormData] = useState({
+      title: '',
+      author: '',
+      description: '',
+      price: '',
+      categories: [],
+      image_url: '',
+      availability: 'available',
+      isbn: '',
+      publisher: '',
+      publication_year: '',
+      pages: '',
+      language: 'hebrew',
+      binding: 'hardcover',
+      dimensions: '',
+      weight: '',
+      stock: '1',
+      is_new_arrival: false,
+      is_new_in_market: false
+    });
 
   useEffect(() => {
     initBooks();
     initCategories();
   }, [initBooks, initCategories]);
 
-  const validateForm = () => {
-    const errors = {};
-    if (!formData.title.trim()) errors.title = 'שם הספר הוא שדה חובה';
-    if (!formData.price || formData.price <= 0) errors.price = 'יש להזין מחיר תקין';
-    if (!formData.category) errors.category = 'יש לבחור קטגוריה';
+    const validateForm = () => {
+      const errors = {};
+      if (!formData.title.trim()) errors.title = 'שם הספר הוא שדה חובה';
+      if (!formData.price || formData.price <= 0) errors.price = 'יש להזין מחיר תקין';
+      if (!formData.categories.length) errors.categories = 'יש לבחור קטגוריה';
     
     if (formData.isbn && !/^[\d-]{10,13}$/.test(formData.isbn)) {
       errors.isbn = 'מספר ISBN לא תקין';
@@ -86,40 +86,58 @@ export default function Products() {
   };
 
   const resetForm = () => {
-    setFormData({
-      title: '',
-      author: '',
-      description: '',
-      price: '',
-      category: '',
-      image_url: '',
-      availability: 'available',
-      isbn: '',
-      publisher: '',
-      publication_year: '',
-      pages: '',
-      language: 'hebrew',
-      binding: 'hardcover',
-      dimensions: '',
-      weight: '',
-      stock: '1',
-      is_new_arrival: false,
-      is_new_in_market: false
-    });
+      setFormData({
+        title: '',
+        author: '',
+        description: '',
+        price: '',
+        categories: [],
+        image_url: '',
+        availability: 'available',
+        isbn: '',
+        publisher: '',
+        publication_year: '',
+        pages: '',
+        language: 'hebrew',
+        binding: 'hardcover',
+        dimensions: '',
+        weight: '',
+        stock: '1',
+        is_new_arrival: false,
+        is_new_in_market: false
+      });
     setImagePreview('');
     setValidationErrors({});
   };
 
-  const handleEdit = (book) => {
-    setSelectedBook(book);
-    setFormData({
-      ...book,
-      price: book.price?.toString() || '',
-      stock: book.stock?.toString() || '1'
-    });
-    setImagePreview(book.image_url || '');
-    setIsModalOpen(true);
-  };
+    const handleEdit = (book) => {
+      setSelectedBook(book);
+      const selected = categories
+        .filter(cat => book.categories?.includes(cat.name))
+        .map(cat => cat.id);
+      setFormData({
+        title: book.title || '',
+        author: book.author || '',
+        description: book.description || '',
+        price: book.price?.toString() || '',
+        categories: selected,
+        image_url: book.image_url || '',
+        availability: book.availability || 'available',
+        isbn: book.isbn || '',
+        publisher: book.publisher || '',
+        publication_year: book.publication_year?.toString() || '',
+        pages: book.pages?.toString() || '',
+        language: book.language || 'hebrew',
+        binding: book.binding || 'hardcover',
+        dimensions: book.dimensions || '',
+        weight: book.weight || '',
+        stock: book.stock?.toString() || '1',
+        is_new_arrival: book.is_new_arrival || false,
+        is_new_in_market: book.is_new_in_market || false
+      });
+      setImagePreview(book.image_url || '');
+      setIsModalOpen(true);
+    };
 
   const handleDelete = async (id) => {
     if (window.confirm('האם אתה בטוח שברצונך למחוק ספר זה?')) {
@@ -274,21 +292,32 @@ export default function Products() {
                 </div>
 
                 <div>
-                  <label className="block text-gray-700 mb-1">קטגוריה *</label>
-                  <select
-                    value={formData.category}
-                    onChange={(e) => setFormData({ ...formData, category: e.target.value })}
-                    className={`w-full border rounded-lg p-2 ${
-                      validationErrors.category ? 'border-red-500' : ''
+                  <label className="block text-gray-700 mb-1">קטגוריות *</label>
+                  <div
+                    className={`grid grid-cols-2 gap-2 max-h-40 overflow-y-auto border rounded p-2 ${
+                      validationErrors.categories ? 'border-red-500' : ''
                     }`}
                   >
-                    <option value="">בחר קטגוריה</option>
                     {categories.map(cat => (
-                      <option key={cat.id} value={cat.name}>{cat.name}</option>
+                      <label key={cat.id} className="flex items-center gap-2">
+                        <input
+                          type="checkbox"
+                          checked={formData.categories.includes(cat.id)}
+                          onChange={(e) => {
+                            if (e.target.checked) {
+                              setFormData(prev => ({ ...prev, categories: [...prev.categories, cat.id] }));
+                            } else {
+                              setFormData(prev => ({ ...prev, categories: prev.categories.filter(id => id !== cat.id) }));
+                            }
+                          }}
+                          className="form-checkbox h-5 w-5 text-[#112a55]"
+                        />
+                        <span>{cat.name}</span>
+                      </label>
                     ))}
-                  </select>
-                  {validationErrors.category && (
-                    <p className="text-red-500 text-sm mt-1">{validationErrors.category}</p>
+                  </div>
+                  {validationErrors.categories && (
+                    <p className="text-red-500 text-sm mt-1">{validationErrors.categories}</p>
                   )}
                 </div>
 


### PR DESCRIPTION
## Summary
- allow selecting multiple categories in admin book manager
- support multi-category selection and validation in products admin view
- display and filter book categories across the site

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689111b827208323881ecfe106807f17