### PR TITLE
Require Hebrew book descriptions

### DIFF
--- a/server/router/analyze.js
+++ b/server/router/analyze.js
@@ -45,10 +45,11 @@ router.post(
     content: [
       {
         type: 'text',
-        text:
-          'Extract the book title, author, description and ISBN from this book cover. ' +
-          'Respond in JSON with keys "title", "author", "description", "isbn".',
-      },
+          text:
+            'Extract the book title, author, description and ISBN from this book cover. ' +
+            'Respond in JSON with keys "title", "author", "description", "isbn". ' +
+            'The description must be written in Hebrew only.',
+        },
       {
         type: 'image_url',
         image_url: {


### PR DESCRIPTION
## Summary
- ensure the OpenAI prompt demands book descriptions in Hebrew

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68912ae2fc088323bf507fe3e3c665ca