### PR TITLE
fix: include credentials for auth

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -22,7 +22,10 @@ if (!process.env.OPENAI_API_KEY) {
 }
 
 const app = express();
-const corsOptions = { origin: process.env.CORS_ORIGIN || '*' };
+const corsOptions = {
+  origin: process.env.CORS_ORIGIN || true,
+  credentials: true
+};
 app.use(cors(corsOptions));
 app.options('*', cors(corsOptions));
 app.use(express.json({ limit: '10mb' }));

--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -19,13 +19,16 @@ async function handleResponse(res) {
 }
 
 export const apiGet = async (path) => {
-  const res = await fetch(`${API_URL}${path}`);
+  const res = await fetch(`${API_URL}${path}`, {
+    credentials: 'include'
+  });
   return handleResponse(res);
 };
 
 export const apiPost = async (path, body) => {
   const res = await fetch(`${API_URL}${path}`, {
     method: 'POST',
+    credentials: 'include',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body)
   });
@@ -35,6 +38,7 @@ export const apiPost = async (path, body) => {
 export const apiPostFormData = async (path, formData) => {
   const res = await fetch(`${API_URL}${path}`, {
     method: 'POST',
+    credentials: 'include',
     body: formData
   });
   return handleResponse(res);


### PR DESCRIPTION
## Summary
- send cookies with all API requests
- enable credentialed CORS requests on server

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vitest run` *(fails: 403 Forbidden)
- `PORT=3001 DATABASE_URL=postgres://user:password@localhost:5432/booksdb node server/index.js` *(started server)*
- `curl -s -D - -H 'Content-Type: application/json' -d '{"email":"test@example.com","password":"pass"}' http://localhost:3001/api/auth/register` *(fails: Database error)*

------
https://chatgpt.com/codex/tasks/task_e_68912d27e650832387205219e73d5281