### PR TITLE
Surface API error messages in auth store

### DIFF
--- a/src/store/authStore.js
+++ b/src/store/authStore.js
@@ -38,8 +38,11 @@ const useAuthStore = create((set) => ({
       return { success: true };
     } catch (error) {
       console.error('Error in signIn:', error);
+      const message = error?.status === 401
+        ? 'פרטי התחברות שגויים'
+        : error?.message || 'שגיאה בהתחברות';
       set({
-        error: 'פרטי התחברות שגויים',
+        error: message,
         loading: false
       });
       return { success: false, error };
@@ -60,8 +63,9 @@ const useAuthStore = create((set) => ({
       return { success: true };
     } catch (error) {
       console.error('Error in signUp:', error);
+      const message = error?.message || 'שגיאה בהרשמה';
       set({
-        error: 'שגיאה בהרשמה',
+        error: message,
         loading: false
       });
       return { success: false, error };


### PR DESCRIPTION
## Summary
- Surface detailed error messages from the API in sign-in and sign-up flows, using a fallback when needed.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689132ed836c8323afc71a8af05a4b2c