### PR TITLE
Ensure users table has password column

### DIFF
--- a/server/router/auth.js
+++ b/server/router/auth.js
@@ -69,7 +69,11 @@ router.post('/api/auth/login', async (req, res) => {
       [email]
     );
     const user = rows[0];
-    if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+    // If the user doesn't exist or the password column is missing/NULL,
+    // return a generic invalid credentials error to avoid leaking details.
+    if (!user || !user.password) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
 
     const match = await bcrypt.compare(password, user.password);
     if (!match) return res.status(401).json({ error: 'Invalid credentials' });

--- a/server/router/setup.js
+++ b/server/router/setup.js
@@ -11,6 +11,12 @@ router.post('/api/setup', async (req, res) => {
       password TEXT NOT NULL
     )`);
 
+    // Ensure the password column exists even if the users table was
+    // created before authentication was implemented.
+    await pool.query(
+      `ALTER TABLE users ADD COLUMN IF NOT EXISTS password TEXT`
+    );
+
     await pool.query(`CREATE TABLE IF NOT EXISTS profiles (
       user_id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
       name TEXT,


### PR DESCRIPTION
## Summary
- Guarantee `users.password` column exists when running setup
- Guard login against missing password field

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689134cfc8008323b36afe5d720643a7