### PR TITLE
Add missing order contact fields to schema

### DIFF
--- a/sql/002_extra_tables.sql
+++ b/sql/002_extra_tables.sql
@@ -3,6 +3,11 @@ CREATE TABLE IF NOT EXISTS orders (
   user_id INTEGER,
   total NUMERIC(10,2) NOT NULL,
   status TEXT DEFAULT 'pending',
+  name TEXT,
+  email TEXT,
+  phone TEXT,
+  shipping_address TEXT,
+  notes TEXT,
   created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
 );
 


### PR DESCRIPTION
## Summary
- add name/email/phone/shipping_address/notes to orders table schema

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68913ec536e88323b94933a10fdd72fa