### PR TITLE
Handle numeric order IDs in PersonalOrders

### DIFF
--- a/src/components/PersonalOrders.jsx
+++ b/src/components/PersonalOrders.jsx
@@ -39,7 +39,7 @@ export default function PersonalOrders() {
           {orders.map((order) => (
             <div key={order.id} className="border rounded-lg p-4">
               <div className="flex justify-between items-center mb-2">
-                <span className="font-bold">הזמנה #{order.id.slice(0, 8)}</span>
+                <span className="font-bold">הזמנה #{String(order.id).slice(0, 8)}</span>
                 <span className="text-sm text-gray-600">
                   {new Date(order.created_at).toLocaleDateString('he-IL')}
                 </span>


### PR DESCRIPTION
## Summary
- Convert order IDs to strings before slicing to avoid runtime errors when IDs are numeric

## Testing
- `npm test` (fails: missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689143ad105c8323a028c5e64671de95