### PR TITLE
Handle missing book data in personal orders

### DIFF
--- a/src/components/PersonalOrders.jsx
+++ b/src/components/PersonalOrders.jsx
@@ -45,9 +45,11 @@ export default function PersonalOrders() {
                 </span>
               </div>
               <div className="space-y-2">
-                {order.order_items.map((item) => (
+                {order.order_items?.map((item) => (
                   <div key={item.id} className="flex justify-between">
-                    <span>{item.book.title} (x{item.quantity})</span>
+                    <span>
+                      {item.book ? `${item.book.title} (x${item.quantity})` : `פריט לא זמין (x${item.quantity})`}
+                    </span>
                     <span>{item.price} ₪</span>
                   </div>
                 ))}


### PR DESCRIPTION
## Summary
- Avoid crashes in `PersonalOrders` when an order item lacks book info by using optional chaining and fallback text

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68914590ce748323b4be7bd23b7351f5