### PR TITLE
feat: send confirmation email after order

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Create a `.env` file (you can copy `.env.example`) and set the following variabl
 - `OPENAI_API_KEY` – API key with access to GPT‑4 Vision used to extract book
   details directly from uploaded cover images. If omitted, the `/api/analyze-book-image`
   endpoint will return a `503` response and book image analysis will be disabled.
+- `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` – SMTP credentials used to
+  send confirmation emails after an order is placed. If these are not set,
+  the server will skip sending emails.
 
 The Vite development server also listens on port `3000`. If you plan to run the
 API server and frontend simultaneously, set `PORT` to a different value (for
@@ -82,6 +85,7 @@ This serves the content of the `dist` directory on the port configured in `vite.
 2. ערכו את הערכים:
    - `DATABASE_URL` – כתובת החיבור למסד הנתונים PostgreSQL.
    - `PORT` – מספר הפורט שעליו ירוץ שרת Express (ברירת מחדל 3000). אם אתם מפעילים גם את שרת Vite במקביל, מומלץ לבחור פורט אחר (למשל 3001).
+   - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` – פרטי שרת SMTP לשליחת אימייל אישור אחרי הזמנה. אם אינם מוגדרים, לא יישלח אימייל.
 
 ### התקנת חבילות
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lucide-react": "^0.486.0",
     "multer": "^1.4.5-lts.1",
     "node-fetch": "^2.6.9",
+    "nodemailer": "^6.9.11",
     "openai": "^4.0.0",
     "pg": "^8.11.1",
     "react": "^18.2.0",

--- a/server/email.js
+++ b/server/email.js
@@ -1,0 +1,31 @@
+export async function sendOrderEmail(order, items = []) {
+  if (!order?.email) return;
+  try {
+    const nodemailer = await import('nodemailer');
+    if (!process.env.SMTP_HOST || !process.env.SMTP_USER || !process.env.SMTP_PASS) {
+      console.warn('SMTP configuration missing, skipping email send');
+      return;
+    }
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT) || 587,
+      secure: process.env.SMTP_SECURE === 'true',
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS
+      }
+    });
+    const itemsList = items
+      .map(i => `${i.title || i.id} x${i.quantity} - $${i.price}`)
+      .join('\n');
+    const text = `Thanks for your order!\n\nOrder #${order.id}\nTotal: ${order.total}\n\nItems:\n${itemsList}`;
+    await transporter.sendMail({
+      from: process.env.MAIL_FROM || process.env.SMTP_USER,
+      to: order.email,
+      subject: `Order Confirmation #${order.id}`,
+      text
+    });
+  } catch (err) {
+    console.error('Error sending order confirmation email', err);
+  }
+}

--- a/server/router/orders.js
+++ b/server/router/orders.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import pool from '../db.js';
 import { getUserFromRequest } from './auth.js';
+import { sendOrderEmail } from '../email.js';
 
 const router = express.Router();
 
@@ -24,6 +25,8 @@ router.post('/api/orders', async (req, res) => {
         [order.id, item.id, item.quantity, item.price]
       );
     }
+
+    await sendOrderEmail(order, items);
 
     res.json(order);
   } catch (err) {


### PR DESCRIPTION
## Summary
- send a confirmation email using SMTP after an order is placed
- document SMTP settings for the server

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689146121fd08323b986cd5948fbad87