### PR TITLE
feat: allow configuring SMTP timeouts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,14 @@ PORT=3001
 CORS_ORIGIN=
 # API key with access to GPT-4 Vision used in /api/analyze-book-image
 OPENAI_API_KEY=
+
+# SMTP settings for order confirmation emails
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASS=
+SMTP_SECURE=false
+# Timeouts in milliseconds
+SMTP_CONNECTION_TIMEOUT=10000
+SMTP_GREETING_TIMEOUT=10000
+MAIL_FROM=

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ Create a `.env` file (you can copy `.env.example`) and set the following variabl
 - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` – SMTP credentials used to
   send confirmation emails after an order is placed. If these are not set,
   the server will skip sending emails.
+- `SMTP_SECURE`, `SMTP_CONNECTION_TIMEOUT`, `SMTP_GREETING_TIMEOUT`, `MAIL_FROM`
+  – optional settings for the SMTP transport. `SMTP_SECURE` enables TLS when set
+  to `true`; the timeout values are in milliseconds.
 
 The Vite development server also listens on port `3000`. If you plan to run the
 API server and frontend simultaneously, set `PORT` to a different value (for
@@ -86,6 +89,9 @@ This serves the content of the `dist` directory on the port configured in `vite.
    - `DATABASE_URL` – כתובת החיבור למסד הנתונים PostgreSQL.
    - `PORT` – מספר הפורט שעליו ירוץ שרת Express (ברירת מחדל 3000). אם אתם מפעילים גם את שרת Vite במקביל, מומלץ לבחור פורט אחר (למשל 3001).
    - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` – פרטי שרת SMTP לשליחת אימייל אישור אחרי הזמנה. אם אינם מוגדרים, לא יישלח אימייל.
+   - `SMTP_SECURE`, `SMTP_CONNECTION_TIMEOUT`, `SMTP_GREETING_TIMEOUT`, `MAIL_FROM` –
+     הגדרות נוספות אופציונליות לשרת ה‑SMTP (`SMTP_SECURE` מפעיל TLS, ערכי ה־timeout
+     במילישניות).
 
 ### התקנת חבילות
 

--- a/server/email.js
+++ b/server/email.js
@@ -13,7 +13,9 @@ export async function sendOrderEmail(order, items = []) {
       auth: {
         user: process.env.SMTP_USER,
         pass: process.env.SMTP_PASS
-      }
+      },
+      connectionTimeout: Number(process.env.SMTP_CONNECTION_TIMEOUT) || 10000,
+      greetingTimeout: Number(process.env.SMTP_GREETING_TIMEOUT) || 10000
     });
     const itemsList = items
       .map(i => `${i.title || i.id} x${i.quantity} - $${i.price}`)


### PR DESCRIPTION
## Summary
- allow configuring connection and greeting timeouts for SMTP mailer
- document SMTP configuration and new optional timeouts in README and .env example

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68914b04a7cc8323b6a7adf372ca4f3c