### PR TITLE
Display product details in customer orders

### DIFF
--- a/server/router/orders.js
+++ b/server/router/orders.js
@@ -47,7 +47,14 @@ router.get('/api/orders', async (req, res) => {
 
     for (const order of orders) {
       const { rows: items } = await pool.query(
-        `SELECT oi.*, b.title FROM order_items oi
+        `SELECT oi.*, json_build_object(
+            'id', b.id,
+            'title', b.title,
+            'author', b.author,
+            'price', b.price,
+            'image_url', b.image_url
+          ) AS book
+         FROM order_items oi
          JOIN books b ON oi.book_id = b.id
          WHERE oi.order_id=$1`,
         [order.id]

--- a/src/components/PersonalOrders.jsx
+++ b/src/components/PersonalOrders.jsx
@@ -46,11 +46,27 @@ export default function PersonalOrders() {
               </div>
               <div className="space-y-2">
                 {order.order_items?.map((item) => (
-                  <div key={item.id} className="flex justify-between">
-                    <span>
-                      {item.book ? `${item.book.title} (x${item.quantity})` : `פריט לא זמין (x${item.quantity})`}
-                    </span>
-                    <span>{item.price} ₪</span>
+                  <div key={item.id} className="flex items-center justify-between gap-4">
+                    {item.book && (
+                      <img
+                        src={
+                          item.book.image_url ||
+                          `https://via.placeholder.com/60x90.png?text=${encodeURIComponent(item.book.title)}`
+                        }
+                        alt={item.book.title}
+                        className="w-12 h-16 object-contain rounded"
+                      />
+                    )}
+                    <div className="flex-1">
+                      <p className="font-medium">
+                        {item.book ? item.book.title : 'פריט לא זמין'}
+                      </p>
+                      {item.book?.author && (
+                        <p className="text-sm text-gray-600">{item.book.author}</p>
+                      )}
+                      <p className="text-sm text-gray-600">כמות: {item.quantity}</p>
+                    </div>
+                    <span className="font-bold">{item.price} ₪</span>
                   </div>
                 ))}
               </div>


### PR DESCRIPTION
## Summary
- Include book information in order items returned by the API
- Show product image, title, author and quantity in the personal orders view

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891d6a338ac8323b418022239c2b5bf