### PR TITLE
feat: load admin orders from database

### DIFF
--- a/server/router/orders.js
+++ b/server/router/orders.js
@@ -62,4 +62,30 @@ router.get('/api/orders', async (req, res) => {
   }
 });
 
+router.get('/api/admin/orders', async (req, res) => {
+  try {
+    const user = await getUserFromRequest(req);
+    if (!user) return res.status(401).json({ error: 'Unauthorized' });
+
+    const { rows: orders } = await pool.query(
+      'SELECT * FROM orders ORDER BY created_at DESC'
+    );
+
+    for (const order of orders) {
+      const { rows: items } = await pool.query(
+        `SELECT oi.*, b.title FROM order_items oi
+         JOIN books b ON oi.book_id = b.id
+         WHERE oi.order_id=$1`,
+        [order.id]
+      );
+      order.order_items = items;
+    }
+
+    res.json(orders);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
 export default router;

--- a/src/pages/admin/Orders.jsx
+++ b/src/pages/admin/Orders.jsx
@@ -1,29 +1,5 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Package, Search, Filter, ChevronDown } from 'lucide-react';
-
-const mockOrders = [
-  {
-    id: '1',
-    date: '2024-03-27',
-    customer: 'ישראל ישראלי',
-    total: 350,
-    status: 'pending',
-    items: [
-      { title: 'שולחן ערוך', quantity: 1, price: 120 },
-      { title: 'משנה ברורה', quantity: 2, price: 115 }
-    ]
-  },
-  {
-    id: '2',
-    date: '2024-03-26',
-    customer: 'יעקב כהן',
-    total: 250,
-    status: 'completed',
-    items: [
-      { title: 'סידור תפילה', quantity: 1, price: 250 }
-    ]
-  }
-];
 
 const statusColors = {
   pending: 'bg-yellow-100 text-yellow-800',
@@ -38,7 +14,27 @@ const statusLabels = {
 };
 
 export default function Orders() {
-  const [orders] = useState(mockOrders);
+  const [orders, setOrders] = useState([]);
+  useEffect(() => {
+    fetch('/api/admin/orders')
+      .then((res) => res.json())
+      .then((data) => {
+        const formatted = data.map((o) => ({
+          id: o.id,
+          date: o.created_at,
+          customer: o.name || o.email || `משתמש ${o.user_id}`,
+          total: Number(o.total),
+          status: o.status,
+          items: o.order_items.map((item) => ({
+            title: item.title,
+            quantity: item.quantity,
+            price: Number(item.price),
+          })),
+        }));
+        setOrders(formatted);
+      })
+      .catch((err) => console.error('Failed to fetch orders', err));
+  }, []);
   const [selectedOrder, setSelectedOrder] = useState(null);
   const [filterStatus, setFilterStatus] = useState('all');
 


### PR DESCRIPTION
## Summary
- fetch admin orders from `/api/admin/orders`
- add backend route to return all orders with items

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6891d6e154e083239280f664729e9183