### PR TITLE
Allow fetching admin orders without auth

### DIFF
--- a/server/router/orders.js
+++ b/server/router/orders.js
@@ -69,37 +69,8 @@ router.get('/api/orders', async (req, res) => {
   }
 });
 
-router.get('/api/admin/orders', async (req, res) => {
+router.get('/api/admin/orders', async (_req, res) => {
   try {
-    const user = await getUserFromRequest(req);
-    if (!user) return res.status(401).json({ error: 'Unauthorized' });
-
-    const { rows: orders } = await pool.query(
-      'SELECT * FROM orders ORDER BY created_at DESC'
-    );
-
-    for (const order of orders) {
-      const { rows: items } = await pool.query(
-        `SELECT oi.*, b.title FROM order_items oi
-         JOIN books b ON oi.book_id = b.id
-         WHERE oi.order_id=$1`,
-        [order.id]
-      );
-      order.order_items = items;
-    }
-
-    res.json(orders);
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: 'Database error' });
-  }
-});
-
-router.get('/api/admin/orders', async (req, res) => {
-  try {
-    const user = await getUserFromRequest(req);
-    if (!user) return res.status(401).json({ error: 'Unauthorized' });
-
     const { rows: orders } = await pool.query(
       'SELECT * FROM orders ORDER BY created_at DESC'
     );


### PR DESCRIPTION
## Summary
- Remove duplicate admin orders route
- Allow `/api/admin/orders` to return all orders without requiring login

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689253fc143083238e7f0dd5befd9865