### PR TITLE
feat: allow multiple images per book

### DIFF
--- a/scripts/seedBooks.js
+++ b/scripts/seedBooks.js
@@ -6,7 +6,7 @@ const books = [
     author: "רבי יוסף קארו",
     description: "ספר יסוד בהלכה",
     price: 120,
-    image_url: "/Uploads/shulchan_aruch.jpg",
+    image_urls: ["/Uploads/shulchan_aruch.jpg"],
     category: "הלכה"
   },
   {
@@ -14,7 +14,7 @@ const books = [
     author: "החפץ חיים",
     description: "ביאור להלכות שו\"ע",
     price: 110,
-    image_url: "/Uploads/mishna_berura.jpg",
+    image_urls: ["/Uploads/mishna_berura.jpg"],
     category: "הלכה"
   },
   {
@@ -22,7 +22,7 @@ const books = [
     author: "",
     description: "התנ\"ך בניקוד מלא",
     price: 80,
-    image_url: "/Uploads/tanach_koren.jpg",
+    image_urls: ["/Uploads/tanach_koren.jpg"],
     category: "תנ\"ך"
   },
   {
@@ -30,7 +30,7 @@ const books = [
     author: "האר\"י",
     description: "יסודות הקבלה",
     price: 130,
-    image_url: "/Uploads/torat_hanistar.jpg",
+    image_urls: ["/Uploads/torat_hanistar.jpg"],
     category: "קבלה"
   },
   {
@@ -38,7 +38,7 @@ const books = [
     author: "הרב אליהו קפלן",
     description: "חגים ומועדים",
     price: 90,
-    image_url: "/Uploads/sefer_hatoda.jpg",
+    image_urls: ["/Uploads/sefer_hatoda.jpg"],
     category: "מחשבה"
   },
   {
@@ -46,7 +46,7 @@ const books = [
     author: "לא נודע",
     description: "טעמי המצוות",
     price: 100,
-    image_url: "/Uploads/sefer_hachinuch.jpg",
+    image_urls: ["/Uploads/sefer_hachinuch.jpg"],
     category: "מצוות"
   },
   {
@@ -54,7 +54,7 @@ const books = [
     author: "תלמיד מהר\"י וייל",
     description: "פסקים ומנהגים",
     price: 85,
-    image_url: "/uploads/leketyosher.jpg",
+    image_urls: ["/uploads/leketyosher.jpg"],
     category: "הלכה"
   },
   {
@@ -62,7 +62,7 @@ const books = [
     author: "הרב קוק",
     description: "פילוסופיה יהודית",
     price: 95,
-    image_url: "/Uploads/orot.jpg",
+    image_urls: ["/Uploads/orot.jpg"],
     category: "מחשבה"
   },
   {
@@ -70,7 +70,7 @@ const books = [
     author: "שונים",
     description: "סיפורי השראה לילדים",
     price: 60,
-    image_url: "/Uploads/sipurei_tzadikim.jpg",
+    image_urls: ["/Uploads/sipurei_tzadikim.jpg"],
     category: "לילדים"
   },
   {
@@ -78,7 +78,7 @@ const books = [
     author: "נוסח ספרד",
     description: "סידור יומי",
     price: 50,
-    image_url: "/Uploads/siddur_tefilla.jpg",
+    image_urls: ["/Uploads/siddur_tefilla.jpg"],
     category: "תפילה"
   }
 ];

--- a/server/router/books.js
+++ b/server/router/books.js
@@ -70,6 +70,7 @@ router.post('/api/books', async (req, res) => {
       description,
       price,
       image_url,
+      image_urls,
       availability,
       isbn,
       publisher,
@@ -95,12 +96,19 @@ router.post('/api/books', async (req, res) => {
       return isNaN(n) ? null : n;
     };
 
+    const imageUrls = Array.isArray(image_urls)
+      ? image_urls
+      : image_url
+      ? [image_url]
+      : [];
+
     const sanitized = {
       title,
       author: author || null,
       description: description || null,
       price: parseFloatOrNull(price),
-      image_url: image_url || null,
+      image_url: imageUrls[0] || null,
+      image_urls: imageUrls,
       availability: availability || 'available',
       isbn: isbn || null,
       publisher: publisher || null,
@@ -117,11 +125,11 @@ router.post('/api/books', async (req, res) => {
 
     const { rows } = await pool.query(
       `INSERT INTO books (
-        title, author, description, price, image_url, availability,
+        title, author, description, price, image_url, image_urls, availability,
         isbn, publisher, publication_year, pages, language, binding,
         dimensions, weight, stock, is_new_arrival, is_new_in_market
       ) VALUES (
-        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17
+        $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18
       ) RETURNING *`,
       [
         sanitized.title,
@@ -129,6 +137,7 @@ router.post('/api/books', async (req, res) => {
         sanitized.description,
         sanitized.price,
         sanitized.image_url,
+        sanitized.image_urls,
         sanitized.availability,
         sanitized.isbn,
         sanitized.publisher,
@@ -185,6 +194,7 @@ router.post('/api/books/:id', async (req, res) => {
       description,
       price,
       image_url,
+      image_urls,
       availability,
       isbn,
       publisher,
@@ -210,12 +220,19 @@ router.post('/api/books/:id', async (req, res) => {
       return isNaN(n) ? null : n;
     };
 
+    const imageUrls = Array.isArray(image_urls)
+      ? image_urls
+      : image_url
+      ? [image_url]
+      : [];
+
     const sanitized = {
       title,
       author: author || null,
       description: description || null,
       price: parseFloatOrNull(price),
-      image_url: image_url || null,
+      image_url: imageUrls[0] || null,
+      image_urls: imageUrls,
       availability: availability || 'available',
       isbn: isbn || null,
       publisher: publisher || null,
@@ -237,26 +254,28 @@ router.post('/api/books/:id', async (req, res) => {
         description=$3,
         price=$4,
         image_url=$5,
-        availability=$6,
-        isbn=$7,
-        publisher=$8,
-        publication_year=$9,
-        pages=$10,
-        language=$11,
-        binding=$12,
-        dimensions=$13,
-        weight=$14,
-        stock=$15,
-        is_new_arrival=$16,
-        is_new_in_market=$17,
+        image_urls=$6,
+        availability=$7,
+        isbn=$8,
+        publisher=$9,
+        publication_year=$10,
+        pages=$11,
+        language=$12,
+        binding=$13,
+        dimensions=$14,
+        weight=$15,
+        stock=$16,
+        is_new_arrival=$17,
+        is_new_in_market=$18,
         updated_at=NOW()
-      WHERE id=$18 RETURNING *`,
+      WHERE id=$19 RETURNING *`,
       [
         sanitized.title,
         sanitized.author,
         sanitized.description,
         sanitized.price,
         sanitized.image_url,
+        sanitized.image_urls,
         sanitized.availability,
         sanitized.isbn,
         sanitized.publisher,

--- a/server/router/orders.js
+++ b/server/router/orders.js
@@ -52,7 +52,8 @@ router.get('/api/orders', async (req, res) => {
             'title', b.title,
             'author', b.author,
             'price', b.price,
-            'image_url', b.image_url
+            'image_url', b.image_url,
+            'image_urls', b.image_urls
           ) AS book
          FROM order_items oi
          JOIN books b ON oi.book_id = b.id

--- a/server/router/setup.js
+++ b/server/router/setup.js
@@ -50,6 +50,7 @@ router.post('/api/setup', async (req, res) => {
       description TEXT,
       price NUMERIC(10,2),
       image_url TEXT,
+      image_urls TEXT[],
       availability TEXT DEFAULT 'available',
       isbn TEXT,
       publisher TEXT,
@@ -65,6 +66,8 @@ router.post('/api/setup', async (req, res) => {
       created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP,
       updated_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP
     )`);
+
+    await pool.query(`ALTER TABLE books ADD COLUMN IF NOT EXISTS image_urls TEXT[]`);
 
     await pool.query(`CREATE TABLE IF NOT EXISTS book_categories (
       book_id INTEGER REFERENCES books(id) ON DELETE CASCADE,

--- a/server/router/wishlist.js
+++ b/server/router/wishlist.js
@@ -11,7 +11,7 @@ router.get('/api/wishlist', async (req, res) => {
     if (!user) return res.status(401).json({ error: 'Unauthorized' });
 
     const { rows } = await pool.query(
-      `SELECT w.id, w.book_id, b.title, b.author, b.price, b.image_url
+      `SELECT w.id, w.book_id, b.title, b.author, b.price, b.image_url, b.image_urls
        FROM wishlist w JOIN books b ON w.book_id = b.id
        WHERE w.user_id=$1 ORDER BY w.created_at DESC`,
       [user.id]

--- a/src/components/BookDetails.jsx
+++ b/src/components/BookDetails.jsx
@@ -31,12 +31,28 @@ export default function BookDetails() {
       <div className="bg-white shadow-xl rounded-2xl overflow-hidden mb-12">
         <div className="grid md:grid-cols-2 gap-8 p-8">
           {/* Image Section */}
-          <div className="flex items-center justify-center bg-[#f8f6f1] rounded-xl p-8">
+          <div className="flex flex-col items-center justify-center bg-[#f8f6f1] rounded-xl p-8">
             <img
-              src={book.image_url || `https://via.placeholder.com/400x600.png?text=${encodeURIComponent(book.title)}`}
+              src={
+                book.image_urls?.[0] ||
+                book.image_url ||
+                `https://via.placeholder.com/400x600.png?text=${encodeURIComponent(book.title)}`
+              }
               alt={book.title}
               className="max-h-[500px] object-contain rounded-lg shadow-lg"
             />
+            {book.image_urls?.length > 1 && (
+              <div className="flex gap-2 mt-4">
+                {book.image_urls.slice(1).map((url, idx) => (
+                  <img
+                    key={idx}
+                    src={url}
+                    alt={`${book.title} ${idx + 2}`}
+                    className="w-16 h-16 object-contain border rounded"
+                  />
+                ))}
+              </div>
+            )}
           </div>
 
           {/* Product Details */}
@@ -112,7 +128,11 @@ export default function BookDetails() {
               >
                 <Link to={`/books/${relatedBook.id}`}>
                   <img
-                    src={relatedBook.image_url || `https://via.placeholder.com/200x300.png?text=${encodeURIComponent(relatedBook.title)}`}
+                    src={
+                      relatedBook.image_urls?.[0] ||
+                      relatedBook.image_url ||
+                      `https://via.placeholder.com/200x300.png?text=${encodeURIComponent(relatedBook.title)}`
+                    }
                     alt={relatedBook.title}
                     className="w-full h-48 object-contain mb-4"
                   />

--- a/src/components/Catalog.jsx
+++ b/src/components/Catalog.jsx
@@ -31,9 +31,9 @@ export default function Catalog() {
             key={book.id}
             className="bg-white rounded-2xl shadow-lg overflow-hidden flex flex-col transform transition-transform duration-300 hover:scale-105"
           >
-            {book.image_url ? (
+            {book.image_urls?.[0] || book.image_url ? (
               <img
-                src={book.image_url}
+                src={book.image_urls?.[0] || book.image_url}
                 alt={book.title}
                 className="w-full h-[300px] object-contain bg-white rounded-t-2xl"
               />

--- a/src/components/CategoriesView.jsx
+++ b/src/components/CategoriesView.jsx
@@ -42,7 +42,11 @@ function CategoryBooks({ books, categoryName, onClose }) {
               >
                 <div className="flex gap-4">
                   <img
-                    src={book.image_url || `https://via.placeholder.com/100x150.png?text=${encodeURIComponent(book.title)}`}
+                    src={
+                      book.image_urls?.[0] ||
+                      book.image_url ||
+                      `https://via.placeholder.com/100x150.png?text=${encodeURIComponent(book.title)}`
+                    }
                     alt={book.title}
                     className="w-24 h-32 object-contain bg-white rounded"
                   />
@@ -178,7 +182,11 @@ export default function CategoriesView() {
             >
               <div className="flex gap-4">
                 <img
-                  src={book.image_url || `https://via.placeholder.com/100x150.png?text=${encodeURIComponent(book.title)}`}
+                  src={
+                    book.image_urls?.[0] ||
+                    book.image_url ||
+                    `https://via.placeholder.com/100x150.png?text=${encodeURIComponent(book.title)}`
+                  }
                   alt={book.title}
                   className="w-24 h-32 object-contain bg-white rounded"
                 />

--- a/src/components/NewInMarket.jsx
+++ b/src/components/NewInMarket.jsx
@@ -48,7 +48,11 @@ export const NewInMarket = () => {
           <div key={book.id} className="w-48 cursor-pointer relative group bg-white rounded-xl shadow-md p-3">
             <Link to={`/books/${book.id}`}>
               <img
-                src={book.image_url ? book.image_url : `https://via.placeholder.com/300x400.png?text=${encodeURIComponent(book.title)}`}
+                src={
+                  book.image_urls?.[0] ||
+                  book.image_url ||
+                  `https://via.placeholder.com/300x400.png?text=${encodeURIComponent(book.title)}`
+                }
                 alt={book.title}
                 className="w-full h-32 object-contain bg-white rounded-lg shadow group-hover:opacity-90 transition-opacity"
               />

--- a/src/components/NewOnSite.jsx
+++ b/src/components/NewOnSite.jsx
@@ -120,7 +120,11 @@ export const NewOnSite = () => {
           >
             <Link to={`/books/${book.id}`}>
               <img
-                src={book.image_url || `https://via.placeholder.com/300x400.png?text=${encodeURIComponent(book.title)}`}
+                src={
+                  book.image_urls?.[0] ||
+                  book.image_url ||
+                  `https://via.placeholder.com/300x400.png?text=${encodeURIComponent(book.title)}`
+                }
                 alt={book.title}
                 className="w-full h-32 object-contain bg-white rounded-lg shadow group-hover:opacity-90 transition-opacity"
               />

--- a/src/components/PersonalOrders.jsx
+++ b/src/components/PersonalOrders.jsx
@@ -50,6 +50,7 @@ export default function PersonalOrders() {
                     {item.book && (
                       <img
                         src={
+                          item.book.image_urls?.[0] ||
                           item.book.image_url ||
                           `https://via.placeholder.com/60x90.png?text=${encodeURIComponent(item.book.title)}`
                         }

--- a/src/components/PersonalWishlist.jsx
+++ b/src/components/PersonalWishlist.jsx
@@ -65,7 +65,11 @@ export default function PersonalWishlist() {
           {wishlist.map((item) => (
             <div key={item.id} className="flex items-center gap-4 border rounded-lg p-4 hover:shadow-lg transition-shadow">
               <img
-                src={item.book.image_url || `https://via.placeholder.com/200x300.png?text=${encodeURIComponent(item.book.title)}`}
+                src={
+                  item.book.image_urls?.[0] ||
+                  item.book.image_url ||
+                  `https://via.placeholder.com/200x300.png?text=${encodeURIComponent(item.book.title)}`
+                }
                 alt={item.book.title}
                 className="w-20 h-28 object-contain rounded"
               />

--- a/src/components/ShoppingCart.jsx
+++ b/src/components/ShoppingCart.jsx
@@ -41,7 +41,11 @@ export default function ShoppingCart() {
             items.map(item => (
               <div key={item.id} className="bg-white rounded-lg shadow p-4 flex gap-4">
                 <img
-                  src={item.image_url || `https://via.placeholder.com/100x150.png?text=${encodeURIComponent(item.title)}`}
+                  src={
+                    item.image_urls?.[0] ||
+                    item.image_url ||
+                    `https://via.placeholder.com/100x150.png?text=${encodeURIComponent(item.title)}`
+                  }
                   alt={item.title}
                   className="w-20 h-28 object-contain bg-white rounded"
                 />

--- a/src/pages/AdminBookManager.js
+++ b/src/pages/AdminBookManager.js
@@ -12,6 +12,7 @@ export default function AdminBookManager() {
     price: "",
     availability: "available",
     image_url: "",
+    additional_images: "",
     categories: []
   });
   const [searchQuery, setSearchQuery] = useState("");
@@ -27,9 +28,23 @@ export default function AdminBookManager() {
     setMessage("");
 
     try {
-      const result = formData.id 
-        ? await updateBook(formData.id, formData)
-        : await addBook(formData);
+      const imageUrls = [
+        formData.image_url,
+        ...formData.additional_images
+          .split(',')
+          .map(s => s.trim())
+          .filter(Boolean)
+      ].filter(Boolean);
+      const payload = {
+        ...formData,
+        image_url: imageUrls[0] || '',
+        image_urls: imageUrls,
+      };
+      delete payload.additional_images;
+
+      const result = formData.id
+        ? await updateBook(formData.id, payload)
+        : await addBook(payload);
 
       if (result.success) {
         setMessage(formData.id ? "✅ הספר עודכן בהצלחה!" : "✅ הספר נוסף בהצלחה!");
@@ -40,6 +55,7 @@ export default function AdminBookManager() {
           price: "",
           availability: "available",
           image_url: "",
+          additional_images: "",
           categories: []
         });
       } else {
@@ -67,7 +83,8 @@ export default function AdminBookManager() {
       description: book.description || "",
       price: book.price?.toString() || "",
       availability: book.availability || "available",
-      image_url: book.image_url || "",
+      image_url: book.image_urls?.[0] || book.image_url || "",
+      additional_images: book.image_urls?.slice(1).join(',') || "",
       categories: selected
     });
   };
@@ -168,6 +185,15 @@ export default function AdminBookManager() {
           className="w-full border px-3 py-2 rounded"
         />
 
+        <input
+          type="text"
+          name="additional_images"
+          value={formData.additional_images}
+          onChange={handleChange}
+          placeholder="קישורי תמונות נוספים (מופרדים בפסיק)"
+          className="w-full border px-3 py-2 rounded"
+        />
+
         <div>
           <label className="block text-gray-700 mb-1">קטגוריות</label>
           <div className="grid grid-cols-2 gap-2 max-h-48 overflow-y-auto border p-2 rounded">
@@ -229,9 +255,9 @@ export default function AdminBookManager() {
                 </button>
               </div>
             </div>
-            {book.image_url && (
+            {(book.image_urls?.[0] || book.image_url) && (
               <img
-                src={book.image_url}
+                src={book.image_urls?.[0] || book.image_url}
                 alt={book.title}
                 className="w-32 h-40 object-contain bg-white rounded mb-2"
               />

--- a/src/pages/BookDetails.js
+++ b/src/pages/BookDetails.js
@@ -36,9 +36,9 @@ export default function BookDetails() {
         ← חזור לקטלוג
       </Link>
       <div className="bg-white shadow rounded-lg p-6 flex flex-col md:flex-row gap-6">
-        {book.image_url ? (
+        {book.image_urls?.[0] || book.image_url ? (
           <img
-            src={`${API_BASE}${book.image_url}`}
+            src={`${API_BASE}${book.image_urls?.[0] || book.image_url}`}
             alt={book.title}
             className="w-full md:w-1/3 h-64 object-contain rounded"
           />

--- a/src/pages/Checkout.jsx
+++ b/src/pages/Checkout.jsx
@@ -196,7 +196,11 @@ export default function Checkout() {
             {items.map(item => (
               <div key={item.id} className="flex gap-4 border-b pb-4">
                 <img
-                  src={item.image_url || `https://via.placeholder.com/100x150.png?text=${encodeURIComponent(item.title)}`}
+                  src={
+                    item.image_urls?.[0] ||
+                    item.image_url ||
+                    `https://via.placeholder.com/100x150.png?text=${encodeURIComponent(item.title)}`
+                  }
                   alt={item.title}
                   className="w-20 h-28 object-contain bg-white rounded"
                 />

--- a/src/pages/admin/AddBook.jsx
+++ b/src/pages/admin/AddBook.jsx
@@ -33,6 +33,7 @@ export default function AddBook() {
     description: '',
     price: '',
     image_url: '',
+    additional_images: '',
     availability: 'available',
     isbn: '',
     publisher: '',
@@ -105,9 +106,18 @@ export default function AddBook() {
         });
       }
 
+      const imageUrls = [
+        imageUrl,
+        ...bookData.additional_images
+          .split(',')
+          .map(s => s.trim())
+          .filter(Boolean)
+      ].filter(Boolean);
+
       const finalBookData = {
         ...bookData,
-        image_url: imageUrl,
+        image_url: imageUrls[0] || '',
+        image_urls: imageUrls,
         categories: selectedCategories
       };
 
@@ -124,6 +134,7 @@ export default function AddBook() {
         description: '',
         price: '',
         image_url: '',
+        additional_images: '',
         availability: 'available',
         isbn: '',
         publisher: '',
@@ -240,6 +251,16 @@ export default function AddBook() {
                 />
               </div>
             )}
+
+            <div className="md:col-span-2">
+              <label className="block text-gray-700 mb-1">קישורי תמונות נוספים (מופרדים בפסיק)</label>
+              <input
+                type="text"
+                value={bookData.additional_images}
+                onChange={(e) => setBookData({ ...bookData, additional_images: e.target.value })}
+                className="w-full border rounded-lg p-2"
+              />
+            </div>
 
             <div>
               <label className="block text-gray-700 mb-1">שם הספר *</label>

--- a/src/pages/admin/Products.jsx
+++ b/src/pages/admin/Products.jsx
@@ -26,6 +26,7 @@ export default function Products() {
       price: '',
       categories: [],
       image_url: '',
+      additional_images: '',
       availability: 'available',
       isbn: '',
       publisher: '',
@@ -66,20 +67,32 @@ export default function Products() {
     e.preventDefault();
     if (!validateForm()) return;
 
+    const imageUrls = [
+      formData.image_url,
+      ...formData.additional_images
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean)
+    ].filter(Boolean);
+
     const bookData = {
       ...formData,
+      image_url: imageUrls[0] || '',
+      image_urls: imageUrls,
       price: Number(formData.price),
       stock: Number(formData.stock),
       pages: formData.pages ? Number(formData.pages) : null,
       publication_year: formData.publication_year ? Number(formData.publication_year) : null
     };
 
+    delete bookData.additional_images;
+
     if (selectedBook) {
       updateBook(selectedBook.id, bookData);
     } else {
       addBook(bookData);
     }
-    
+
     setIsModalOpen(false);
     setSelectedBook(null);
     resetForm();
@@ -93,6 +106,7 @@ export default function Products() {
         price: '',
         categories: [],
         image_url: '',
+        additional_images: '',
         availability: 'available',
         isbn: '',
         publisher: '',
@@ -121,7 +135,8 @@ export default function Products() {
         description: book.description || '',
         price: book.price?.toString() || '',
         categories: selected,
-        image_url: book.image_url || '',
+        image_url: book.image_urls?.[0] || book.image_url || '',
+        additional_images: book.image_urls?.slice(1).join(',') || '',
         availability: book.availability || 'available',
         isbn: book.isbn || '',
         publisher: book.publisher || '',
@@ -135,7 +150,7 @@ export default function Products() {
         is_new_arrival: book.is_new_arrival || false,
         is_new_in_market: book.is_new_in_market || false
       });
-      setImagePreview(book.image_url || '');
+      setImagePreview(book.image_urls?.[0] || book.image_url || '');
       setIsModalOpen(true);
     };
 
@@ -192,9 +207,9 @@ export default function Products() {
         {filteredBooks.map((book) => (
           <div key={book.id} className="bg-white rounded-xl shadow-lg overflow-hidden">
             <div className="aspect-w-3 aspect-h-4 bg-gray-100">
-              {book.image_url ? (
+              {book.image_urls?.[0] || book.image_url ? (
                 <img
-                  src={book.image_url}
+                  src={book.image_urls?.[0] || book.image_url}
                   alt={book.title}
                   className="w-full h-48 object-contain"
                 />
@@ -484,6 +499,17 @@ export default function Products() {
                     />
                   )}
                 </div>
+              </div>
+
+              <div>
+                <label className="block text-gray-700 mb-1">תמונות נוספות (מופרדות בפסיק)</label>
+                <input
+                  type="text"
+                  value={formData.additional_images}
+                  onChange={(e) => setFormData({ ...formData, additional_images: e.target.value })}
+                  className="w-full border rounded-lg p-2"
+                  placeholder="קישורים נוספים"
+                />
               </div>
 
               <div>


### PR DESCRIPTION
## Summary
- store and expose arrays of image URLs for each book
- support extra image inputs in admin tools
- render books using first image with optional gallery

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68925c09eb448323bf4f378f2007607b