### PR TITLE
Handle non-json responses for admin orders

### DIFF
--- a/src/pages/admin/Orders.jsx
+++ b/src/pages/admin/Orders.jsx
@@ -20,8 +20,13 @@ export default function Orders() {
 
   useEffect(() => {
     fetch('/api/admin/orders')
-      .then((res) => {
+      .then(async (res) => {
         console.log('📡 קיבלנו תגובה מהשרת:', res);
+        const contentType = res.headers.get('content-type');
+        if (!res.ok || !contentType || !contentType.includes('application/json')) {
+          const text = await res.text();
+          throw new Error(text || 'Invalid JSON response');
+        }
         return res.json();
       })
       .then((data) => {


### PR DESCRIPTION
## Summary
- avoid JSON parse errors by validating content type for admin orders

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68926821ac8c83239045216f00c47433