### PR TITLE
feat: add password reset flow

### DIFF
--- a/server/router/auth.js
+++ b/server/router/auth.js
@@ -4,6 +4,7 @@ import bcrypt from 'bcrypt';
 import pool from '../db.js';
 
 export const sessions = {};
+const passwordResetTokens = {};
 
 function parseCookies(header = '') {
   const cookies = {};
@@ -24,6 +25,34 @@ export async function getUserFromRequest(req) {
 }
 
 const router = express.Router();
+
+async function sendPasswordResetEmail(email, token) {
+  try {
+    const nodemailer = await import('nodemailer');
+    if (!process.env.SMTP_HOST || !process.env.SMTP_USER || !process.env.SMTP_PASS) {
+      console.warn('SMTP configuration missing, reset link:', token);
+      return;
+    }
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT) || 587,
+      secure: process.env.SMTP_SECURE === 'true',
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS
+      }
+    });
+    const resetUrl = `${process.env.FRONTEND_URL || ''}/reset-password?token=${token}`;
+    await transporter.sendMail({
+      from: process.env.MAIL_FROM || process.env.SMTP_USER,
+      to: email,
+      subject: 'Password Reset',
+      text: `Click the link to reset your password: ${resetUrl}`
+    });
+  } catch (err) {
+    console.error('Error sending password reset email:', err);
+  }
+}
 
 router.get('/api/auth/user', async (req, res) => {
   const user = await getUserFromRequest(req);
@@ -132,6 +161,51 @@ router.post('/api/auth/login', async (req, res) => {
     sessions[sid] = user.id;
     res.cookie('session_id', sid, { httpOnly: true });
     res.json({ user: { id: user.id, email: user.email } });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+router.post('/api/auth/request-password-reset', async (req, res) => {
+  try {
+    const { email } = req.body;
+    if (!email) return res.status(400).json({ error: 'Missing email' });
+    const { rows } = await pool.query('SELECT id FROM users WHERE email=$1', [email]);
+    if (rows.length) {
+      const token = crypto.randomBytes(32).toString('hex');
+      passwordResetTokens[token] = {
+        userId: rows[0].id,
+        expires: Date.now() + 1000 * 60 * 60
+      };
+      await sendPasswordResetEmail(email, token);
+    }
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+router.post('/api/auth/reset-password', async (req, res) => {
+  try {
+    const { token, password } = req.body;
+    const data = passwordResetTokens[token];
+    if (!data || data.expires < Date.now()) {
+      return res.status(400).json({ error: 'Invalid or expired token' });
+    }
+    const hashed = await bcrypt.hash(password, 10);
+    try {
+      await pool.query('UPDATE users SET password=$1 WHERE id=$2', [hashed, data.userId]);
+    } catch (err) {
+      if (err.code === '42703') {
+        await pool.query('UPDATE users SET password_hash=$1 WHERE id=$2', [hashed, data.userId]);
+      } else {
+        throw err;
+      }
+    }
+    delete passwordResetTokens[token];
+    res.json({ success: true });
   } catch (err) {
     console.error(err);
     res.status(500).json({ error: 'Database error' });

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import NotFound from "./components/NotFound";
 import About from "./pages/About";
 import Contact from "./pages/Contact";
 import Login from "./pages/Login";
+import ResetPassword from "./pages/ResetPassword";
 import PersonalArea from "./pages/PersonalArea";
 import Checkout from "./pages/Checkout";
 import Terms from "./pages/Terms";
@@ -57,6 +58,7 @@ function App() {
             <Route path="/about" element={<About />} />
             <Route path="/contact" element={<Contact />} />
             <Route path="/login" element={<Login />} />
+            <Route path="/reset-password" element={<ResetPassword />} />
             <Route path="/personal/*" element={<PersonalArea />} />
             <Route path="/checkout" element={<Checkout />} />
             <Route path="/terms" element={<Terms />} />

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -4,35 +4,36 @@ import useAuthStore from '../store/authStore';
 
 export default function Login() {
   const navigate = useNavigate();
-  const { signIn, signUp, error } = useAuthStore();
-  const [isLogin, setIsLogin] = useState(true);
-  const [formData, setFormData] = useState({
-    email: '',
-    password: ''
-  });
+  const { signIn, signUp, requestPasswordReset, error } = useAuthStore();
+  const [mode, setMode] = useState('login');
+  const [formData, setFormData] = useState({ email: '', password: '' });
+  const [message, setMessage] = useState('');
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     const { email, password } = formData;
-    
-    const result = isLogin 
-      ? await signIn(email, password)
-      : await signUp(email, password);
-
-    if (result.success) {
-      navigate('/personal');
+    let result;
+    if (mode === 'login') {
+      result = await signIn(email, password);
+      if (result.success) navigate('/personal');
+    } else if (mode === 'register') {
+      result = await signUp(email, password);
+      if (result.success) navigate('/personal');
+    } else {
+      result = await requestPasswordReset(email);
+      if (result.success) setMessage('אם הכתובת קיימת, נשלח קישור לאיפוס סיסמה');
     }
   };
 
   const handleChange = (e) => {
     const { name, value } = e.target;
-    setFormData(prev => ({ ...prev, [name]: value }));
+    setFormData((prev) => ({ ...prev, [name]: value }));
   };
 
   return (
     <div className="max-w-md mx-auto p-8">
       <h1 className="text-3xl font-bold text-[#112a55] mb-6 text-center">
-        {isLogin ? 'התחברות' : 'הרשמה'}
+        {mode === 'login' ? 'התחברות' : mode === 'register' ? 'הרשמה' : 'שחזור סיסמה'}
       </h1>
 
       <div className="bg-white rounded-xl shadow-lg p-6">
@@ -52,44 +53,62 @@ export default function Login() {
             />
           </div>
 
-          <div>
-            <label htmlFor="password" className="block text-gray-700 mb-1">
-              סיסמה
-            </label>
-            <input
-              type="password"
-              id="password"
-              name="password"
-              value={formData.password}
-              onChange={handleChange}
-              required
-              className="w-full border rounded p-2"
-            />
-          </div>
-
-          {error && (
-            <p className="text-red-600 text-sm">{error}</p>
+          {mode !== 'reset' && (
+            <div>
+              <label htmlFor="password" className="block text-gray-700 mb-1">
+                סיסמה
+              </label>
+              <input
+                type="password"
+                id="password"
+                name="password"
+                value={formData.password}
+                onChange={handleChange}
+                required
+                className="w-full border rounded p-2"
+              />
+            </div>
           )}
+
+          {error && <p className="text-red-600 text-sm">{error}</p>}
+          {message && <p className="text-green-600 text-sm">{message}</p>}
 
           <button
             type="submit"
             className="w-full bg-[#a48327] text-white py-2 rounded hover:bg-[#8b6f1f] transition-colors"
           >
-            {isLogin ? 'התחבר' : 'הירשם'}
+            {mode === 'login' ? 'התחבר' : mode === 'register' ? 'הירשם' : 'שלח קישור'}
           </button>
 
           <p className="text-center text-gray-600">
-            {isLogin ? 'אין לך חשבון?' : 'כבר יש לך חשבון?'}
+            {mode === 'login'
+              ? 'אין לך חשבון?'
+              : mode === 'register'
+              ? 'כבר יש לך חשבון?'
+              : 'נזכרת בסיסמה?'}
             <button
               type="button"
-              onClick={() => setIsLogin(!isLogin)}
+              onClick={() => setMode(mode === 'login' ? 'register' : 'login')}
               className="text-[#112a55] hover:underline mr-1"
             >
-              {isLogin ? 'הירשם' : 'התחבר'}
+              {mode === 'login' ? 'הירשם' : 'התחבר'}
             </button>
           </p>
+          {mode === 'login' && (
+            <button
+              type="button"
+              onClick={() => {
+                setMode('reset');
+                setMessage('');
+              }}
+              className="text-[#112a55] hover:underline block mx-auto mt-2"
+            >
+              שכחת סיסמה?
+            </button>
+          )}
         </form>
       </div>
     </div>
   );
 }
+

--- a/src/pages/ResetPassword.jsx
+++ b/src/pages/ResetPassword.jsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import useAuthStore from '../store/authStore';
+
+export default function ResetPassword() {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token');
+  const navigate = useNavigate();
+  const { resetPassword, error } = useAuthStore();
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const result = await resetPassword(token, password);
+    if (result.success) {
+      setMessage('הסיסמה עודכנה בהצלחה');
+      setTimeout(() => navigate('/login'), 2000);
+    }
+  };
+
+  return (
+    <div className="max-w-md mx-auto p-8">
+      <h1 className="text-3xl font-bold text-[#112a55] mb-6 text-center">איפוס סיסמה</h1>
+      <div className="bg-white rounded-xl shadow-lg p-6">
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="password" className="block text-gray-700 mb-1">
+              סיסמה חדשה
+            </label>
+            <input
+              type="password"
+              id="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              className="w-full border rounded p-2"
+            />
+          </div>
+          {error && <p className="text-red-600 text-sm">{error}</p>}
+          {message && <p className="text-green-600 text-sm">{message}</p>}
+          <button
+            type="submit"
+            className="w-full bg-[#a48327] text-white py-2 rounded hover:bg-[#8b6f1f] transition-colors"
+          >
+            שמור
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+

--- a/src/store/authStore.js
+++ b/src/store/authStore.js
@@ -72,6 +72,34 @@ const useAuthStore = create((set) => ({
     }
   },
 
+  requestPasswordReset: async (email) => {
+    try {
+      set({ loading: true, error: null });
+      await apiPost('/api/auth/request-password-reset', { email });
+      set({ loading: false });
+      return { success: true };
+    } catch (error) {
+      console.error('Error in requestPasswordReset:', error);
+      const message = error?.message || 'שגיאה בשליחת קישור';
+      set({ error: message, loading: false });
+      return { success: false, error };
+    }
+  },
+
+  resetPassword: async (token, password) => {
+    try {
+      set({ loading: true, error: null });
+      await apiPost('/api/auth/reset-password', { token, password });
+      set({ loading: false });
+      return { success: true };
+    } catch (error) {
+      console.error('Error in resetPassword:', error);
+      const message = error?.message || 'שגיאה באיפוס הסיסמה';
+      set({ error: message, loading: false });
+      return { success: false, error };
+    }
+  },
+
   signOut: async () => {
     try {
       await apiPost('/api/auth/logout', {});


### PR DESCRIPTION
## Summary
- add API routes for requesting and completing password resets
- add password reset functions and screens on the client

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68927eccd10c83238a886622d9b51332