### PR TITLE
Gracefully handle missing orders table

### DIFF
--- a/server/router/orders.js
+++ b/server/router/orders.js
@@ -68,6 +68,9 @@ router.get('/api/orders', async (req, res) => {
     res.json(orders);
   } catch (err) {
     console.error(err);
+    if (err.code === '42P01') {
+      return res.json([]);
+    }
     res.status(500).json({ error: 'Database error' });
   }
 });


### PR DESCRIPTION
## Summary
- Prevent `/api/orders` from throwing database errors when the `orders` table is absent by returning an empty array instead.

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68927fea4098832389e9da361458368b