### PR TITLE
Close order modal and email customer on status change

### DIFF
--- a/server/router/orders.js
+++ b/server/router/orders.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import pool from '../db.js';
 import { getUserFromRequest } from './auth.js';
-import { sendOrderEmail } from '../email.js';
+import { sendOrderEmail, sendOrderStatusEmail } from '../email.js';
 
 const router = express.Router();
 
@@ -111,6 +111,8 @@ router.post('/api/admin/orders/:id/status', async (req, res) => {
     if (rows.length === 0) {
       return res.status(404).json({ error: 'Order not found' });
     }
+
+    await sendOrderStatusEmail(rows[0]);
 
     res.json(rows[0]);
   } catch (err) {

--- a/src/pages/admin/Orders.jsx
+++ b/src/pages/admin/Orders.jsx
@@ -190,7 +190,7 @@ export default function Orders() {
                     apiPost(`/api/admin/orders/${selectedOrder.id}/status`, { status: statusUpdate })
                       .then(updated => {
                         setOrders(prev => prev.map(o => o.id === updated.id ? { ...o, status: updated.status } : o));
-                        setSelectedOrder(prev => ({ ...prev, status: updated.status }));
+                        setSelectedOrder(null);
                       })
                       .catch(err => console.error('❌ שגיאה בעדכון סטטוס:', err));
                   }}


### PR DESCRIPTION
## Summary
- close admin order modal after updating status
- send status update email to the customer

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689284f6c0888323b9b405b7e393b622