### PR TITLE
Handle missing image_urls column in orders query

### DIFF
--- a/server/router/orders.js
+++ b/server/router/orders.js
@@ -48,14 +48,21 @@ router.get('/api/orders', async (req, res) => {
     );
 
     for (const order of orders) {
+      const { rows: col } = await pool.query(
+        `SELECT column_name FROM information_schema.columns
+         WHERE table_name='books' AND column_name='image_urls'`
+      );
+      const hasImageUrls = col.length > 0;
+      const imageFields = hasImageUrls
+        ? "'image_url', b.image_url, 'image_urls', b.image_urls"
+        : "'image_url', b.image_url";
       const { rows: items } = await pool.query(
         `SELECT oi.*, json_build_object(
             'id', b.id,
             'title', b.title,
             'author', b.author,
             'price', b.price,
-            'image_url', b.image_url,
-            'image_urls', b.image_urls
+            ${imageFields}
           ) AS book
          FROM order_items oi
          JOIN books b ON oi.book_id = b.id


### PR DESCRIPTION
## Summary
- avoid database errors when the `books` table lacks `image_urls` by checking column existence before building order item book data

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6892839fcba083239df3c1121945f7f8