### PR TITLE
feat: redesign and localize emails

### DIFF
--- a/server/email.js
+++ b/server/email.js
@@ -1,9 +1,31 @@
+export function buildEmailTemplate(title, contentHtml) {
+  return `
+    <!DOCTYPE html>
+    <html lang="he" dir="rtl">
+      <head>
+        <meta charset="UTF-8" />
+        <title>${title}</title>
+      </head>
+      <body style="font-family:Arial,sans-serif; background-color:#f7f7f7; padding:20px;">
+        <div style="max-width:600px; margin:0 auto; background-color:#ffffff; border-radius:8px; overflow:hidden;">
+          <div style="background-color:#112a55; color:#ffffff; padding:20px;">
+            <h1 style="margin:0; font-size:24px;">תלפיות ספרי קודש</h1>
+          </div>
+          <div style="padding:20px; color:#333333;">
+            ${contentHtml}
+          </div>
+        </div>
+      </body>
+    </html>
+  `;
+}
+
 export async function sendOrderEmail(order, items = []) {
   if (!order?.email) return;
 
   try {
     const nodemailer = await import('nodemailer');
-    
+
     if (!process.env.SMTP_HOST || !process.env.SMTP_USER || !process.env.SMTP_PASS) {
       console.warn('SMTP configuration missing, skipping email send');
       return;
@@ -25,10 +47,10 @@ export async function sendOrderEmail(order, items = []) {
     await transporter.verify();
 
     const itemsList = items
-      .map(i => `${i.title || i.id} x${i.quantity} - $${Number(i.price).toFixed(2)}`)
+      .map(i => `${i.title || i.id} x${i.quantity} - ₪${Number(i.price).toFixed(2)}`)
       .join('\n');
 
-    const text = `Thanks for your order!\n\nOrder #${order.id}\nTotal: $${Number(order.total).toFixed(2)}\n\nItems:\n${itemsList}`;
+    const text = `תודה על הזמנתך!\n\nהזמנה #${order.id}\nסכום כולל: ₪${Number(order.total).toFixed(2)}\n\nפריטים:\n${itemsList}`;
 
     const itemsRows = items
       .map(
@@ -36,54 +58,43 @@ export async function sendOrderEmail(order, items = []) {
           <tr>
             <td style="padding:8px; border-bottom:1px solid #e2e8f0;">${i.title || i.id}</td>
             <td style="padding:8px; text-align:center; border-bottom:1px solid #e2e8f0;">${i.quantity}</td>
-            <td style="padding:8px; text-align:right; border-bottom:1px solid #e2e8f0;">$${Number(i.price).toFixed(2)}</td>
+            <td style="padding:8px; text-align:left; border-bottom:1px solid #e2e8f0;">₪${Number(i.price).toFixed(2)}</td>
           </tr>`
       )
       .join('');
 
-    const html = `
-      <!DOCTYPE html>
-      <html lang="en">
-        <head>
-          <meta charset="UTF-8" />
-          <title>Order Confirmation</title>
-        </head>
-        <body style="font-family:Arial,sans-serif; background-color:#f7f7f7; padding:20px;">
-          <div style="max-width:600px; margin:0 auto; background-color:#ffffff; border-radius:8px; overflow:hidden;">
-            <div style="background-color:#112a55; color:#ffffff; padding:20px;">
-              <h1 style="margin:0; font-size:24px;">Thank you for your order!</h1>
-            </div>
-            <div style="padding:20px; color:#333333;">
-              <p style="font-size:16px;">Order <strong>#${order.id}</strong></p>
-              <table style="width:100%; border-collapse:collapse; margin-top:10px;">
-                <thead>
-                  <tr>
-                    <th style="text-align:left; border-bottom:1px solid #e2e8f0; padding:8px;">Item</th>
-                    <th style="text-align:center; border-bottom:1px solid #e2e8f0; padding:8px;">Qty</th>
-                    <th style="text-align:right; border-bottom:1px solid #e2e8f0; padding:8px;">Price</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  ${itemsRows}
-                </tbody>
-                <tfoot>
-                  <tr>
-                    <td colspan="2" style="padding:8px; text-align:right; font-weight:bold; border-top:1px solid #e2e8f0;">Total</td>
-                    <td style="padding:8px; text-align:right; font-weight:bold; border-top:1px solid #e2e8f0;">$${Number(order.total).toFixed(2)}</td>
-                  </tr>
-                </tfoot>
-              </table>
-              <p style="margin-top:20px;">We will contact you soon to arrange payment and delivery.</p>
-            </div>
-          </div>
-        </body>
-      </html>
+    const htmlContent = `
+      <h2 style="margin-top:0;">תודה על הזמנתך!</h2>
+      <p style="font-size:16px;">הזמנה <strong>#${order.id}</strong></p>
+      <table style="width:100%; border-collapse:collapse; margin-top:10px;">
+        <thead>
+          <tr>
+            <th style="text-align:right; border-bottom:1px solid #e2e8f0; padding:8px;">פריט</th>
+            <th style="text-align:center; border-bottom:1px solid #e2e8f0; padding:8px;">כמות</th>
+            <th style="text-align:left; border-bottom:1px solid #e2e8f0; padding:8px;">מחיר</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${itemsRows}
+        </tbody>
+        <tfoot>
+          <tr>
+            <td colspan="2" style="padding:8px; text-align:left; font-weight:bold; border-top:1px solid #e2e8f0;">סך הכל</td>
+            <td style="padding:8px; text-align:left; font-weight:bold; border-top:1px solid #e2e8f0;">₪${Number(order.total).toFixed(2)}</td>
+          </tr>
+        </tfoot>
+      </table>
+      <p style="margin-top:20px;">ניצור איתך קשר בהקדם לתיאום תשלום ומשלוח.</p>
     `;
 
+    const html = buildEmailTemplate('אישור הזמנה', htmlContent);
+
+    const from = `"תלפיות ספרי קודש" <${process.env.MAIL_FROM || process.env.SMTP_USER}>`;
+
     await transporter.sendMail({
-      from: process.env.MAIL_FROM || process.env.SMTP_USER,
+      from,
       to: order.email,
-      subject: `Order Confirmation #${order.id}`,
+      subject: `אישור הזמנה #${order.id}`,
       text,
       html,
     });
@@ -127,11 +138,19 @@ export async function sendOrderStatusEmail(order) {
     };
     const statusText = statusLabels[order.status] || order.status;
 
-    const text = `הזמנתך מספר ${order.id} עודכנה לסטטוס: ${statusText}`;
-    const html = `<p>${text}</p>`;
+    const text = `סטטוס הזמנתך מספר ${order.id} עודכן ל: ${statusText}`;
+
+    const htmlContent = `
+      <h2 style="margin-top:0;">עדכון סטטוס הזמנה</h2>
+      <p>סטטוס הזמנתך מספר <strong>${order.id}</strong> עודכן ל: <strong>${statusText}</strong>.</p>
+    `;
+
+    const html = buildEmailTemplate('עדכון סטטוס הזמנה', htmlContent);
+
+    const from = `"תלפיות ספרי קודש" <${process.env.MAIL_FROM || process.env.SMTP_USER}>`;
 
     await transporter.sendMail({
-      from: process.env.MAIL_FROM || process.env.SMTP_USER,
+      from,
       to: order.email,
       subject: `עדכון סטטוס הזמנה #${order.id}`,
       text,

--- a/server/router/auth.js
+++ b/server/router/auth.js
@@ -2,6 +2,7 @@ import express from 'express';
 import crypto from 'crypto';
 import bcrypt from 'bcrypt';
 import pool from '../db.js';
+import { buildEmailTemplate } from '../email.js';
 
 export const sessions = {};
 const passwordResetTokens = {};
@@ -43,11 +44,20 @@ async function sendPasswordResetEmail(email, token) {
       }
     });
     const resetUrl = `${process.env.FRONTEND_URL || ''}/reset-password?token=${token}`;
+    const text = `לאיפוס הסיסמה שלך לחץ על הקישור: ${resetUrl}`;
+    const htmlContent = `
+      <h2 style="margin-top:0;">איפוס סיסמה</h2>
+      <p>לחץ על הקישור הבא כדי לאפס את הסיסמה שלך:</p>
+      <p><a href="${resetUrl}">איפוס סיסמה</a></p>
+    `;
+    const html = buildEmailTemplate('איפוס סיסמה', htmlContent);
+    const from = `"תלפיות ספרי קודש" <${process.env.MAIL_FROM || process.env.SMTP_USER}>`;
     await transporter.sendMail({
-      from: process.env.MAIL_FROM || process.env.SMTP_USER,
+      from,
       to: email,
-      subject: 'Password Reset',
-      text: `Click the link to reset your password: ${resetUrl}`
+      subject: 'איפוס סיסמה',
+      text,
+      html
     });
   } catch (err) {
     console.error('Error sending password reset email:', err);


### PR DESCRIPTION
## Summary
- improve email styling with reusable template and Hebrew content
- translate and style order confirmation and status emails
- localize password reset email and add branded sender name

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689289a078ac8323a54dc439bfdf7ca7