### PR TITLE
Remove welcome section from home page

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -7,11 +7,6 @@ import Catalog from '../components/Catalog';
 export default function Home() {
   return (
     <div className="space-y-12">
-      <section className="bg-white rounded-2xl shadow-lg p-8 text-center">
-        <h1 className="text-3xl mb-4">ברוכים הבאים לספרי קודש תלפיות</h1>
-        <p>חנות מקוונת למבחר ספרי קודש איכותיים.</p>
-      </section>
-
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
         <PromoBoxes />
       </div>


### PR DESCRIPTION
## Summary
- remove welcome text section from home page, leaving promo and catalog components

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68931abae8088323a484d298bbc01904