### PR TITLE
Rearrange home page catalog layout

### DIFF
--- a/src/components/Catalog.jsx
+++ b/src/components/Catalog.jsx
@@ -25,7 +25,7 @@ export default function Catalog() {
     <div className="p-4 max-w-6xl mx-auto">
       <h2 className="text-3xl font-bold mb-6 text-center text-[#112a55]">קטלוג הספרים</h2>
 
-      <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+      <div className="grid gap-8 grid-cols-1 sm:grid-cols-2 lg:grid-cols-4">
         {books.map((book) => (
           <div
             key={book.id}
@@ -35,13 +35,13 @@ export default function Catalog() {
               <img
                 src={book.image_urls?.[0] || book.image_url}
                 alt={book.title}
-                className="w-full h-[300px] object-contain bg-white rounded-t-2xl"
+                className="w-full h-[250px] object-contain bg-white rounded-t-2xl"
               />
             ) : (
               <img
                 src={`https://via.placeholder.com/300x400.png?text=${encodeURIComponent(book.title)}`}
                 alt={book.title}
-                className="w-full h-[300px] object-contain bg-white rounded-t-2xl"
+                className="w-full h-[250px] object-contain bg-white rounded-t-2xl"
               />
             )}
 

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -7,13 +7,13 @@ import Catalog from '../components/Catalog';
 export default function Home() {
   return (
     <div className="space-y-12">
+      <Catalog />
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
         <PromoBoxes />
       </div>
 
       <NewOnSite />
       <NewInMarket />
-      <Catalog />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Move catalog section to the top of the home page
- Display four catalog items per row with larger spacing
- Reduce catalog image heights for a more compact grid

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68931ef8b06c8323b1355725c77f70ea