### PR TITLE
fix: update email logo URL

### DIFF
--- a/server/email.js
+++ b/server/email.js
@@ -9,7 +9,7 @@ export function buildEmailTemplate(title, contentHtml) {
       <body style="font-family:Arial,sans-serif; background-color:#f7f7f7; padding:20px; direction:rtl; text-align:right;">
         <div style="max-width:600px; margin:0 auto; background-color:#ffffff; border-radius:8px; overflow:hidden;">
           <div style="background-color:#112a55; color:#ffffff; padding:20px; text-align:center;">
-            <img src="https://talpiot-books.co.il/logo.png" alt="תלפיות ספרי קודש" style="max-width:200px; margin-bottom:10px;" />
+            <img src="https://talpiot-books.com/logo.png" alt="תלפיות ספרי קודש" style="max-width:200px; margin-bottom:10px;" />
             <h1 style="margin:0; font-size:24px;">תלפיות ספרי קודש</h1>
           </div>
           <div style="padding:20px; color:#333333;">

--- a/src/pages/admin/EmailPreview.jsx
+++ b/src/pages/admin/EmailPreview.jsx
@@ -19,7 +19,7 @@ export default function EmailPreview() {
 
   const emailHeader = `
     <div style="text-align: center; margin-bottom: 30px;">
-      <img src="https://talpiot-books.co.il/logo.png" alt="ספרי קודש תלפיות" style="max-width: 200px; margin-bottom: 15px;" />
+      <img src="https://talpiot-books.com/logo.png" alt="ספרי קודש תלפיות" style="max-width: 200px; margin-bottom: 15px;" />
       <div style="color: #666; font-size: 14px;">
         <p>טלפון: 050-418-1216</p>
         <p>רחוב הרב קוק 12, ירושלים</p>


### PR DESCRIPTION
## Summary
- use new https://talpiot-books.com/logo.png path in email template and preview

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6893219008c0832397dd4faf6c1eafbc