### PR TITLE
feat: save uploaded images to server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+uploads/

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import dotenv from 'dotenv';
 import cors from 'cors';
+import path from 'path';
 import { logError } from './logger.js';
 import pool from './db.js';
 
@@ -13,6 +14,7 @@ import ordersRouter from './router/orders.js';
 import wishlistRouter from './router/wishlist.js';
 import contentRouter from './router/content.js';
 import setupRouter from './router/setup.js';
+import uploadRouter from './router/upload.js';
 
 dotenv.config();
 
@@ -36,6 +38,8 @@ app.use((req, res, next) => {
   next();
 });
 
+app.use('/uploads', express.static(path.join(process.cwd(), 'uploads')));
+
 app.use(analyzeRouter);
 app.use(authRouter);
 app.use(profileRouter);
@@ -45,6 +49,7 @@ app.use(ordersRouter);
 app.use(wishlistRouter);
 app.use(contentRouter);
 app.use(setupRouter);
+app.use(uploadRouter);
 
 const PORT = process.env.PORT || 3000;
 

--- a/server/router/upload.js
+++ b/server/router/upload.js
@@ -1,0 +1,29 @@
+import express from 'express';
+import multer from 'multer';
+import path from 'path';
+import fs from 'fs';
+
+const router = express.Router();
+const uploadDir = path.join(process.cwd(), 'uploads');
+fs.mkdirSync(uploadDir, { recursive: true });
+
+const storage = multer.diskStorage({
+  destination: (_, __, cb) => cb(null, uploadDir),
+  filename: (_, file, cb) => {
+    const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1e9);
+    const ext = path.extname(file.originalname);
+    cb(null, `${uniqueSuffix}${ext}`);
+  }
+});
+
+const upload = multer({ storage });
+
+router.post('/api/upload-image', upload.single('image'), (req, res) => {
+  if (!req.file) {
+    return res.status(400).json({ error: 'No file uploaded' });
+  }
+  const url = `/uploads/${req.file.filename}`;
+  res.json({ url });
+});
+
+export default router;

--- a/src/pages/admin/AddBook.jsx
+++ b/src/pages/admin/AddBook.jsx
@@ -98,12 +98,10 @@ export default function AddBook() {
 
       if (imageFile) {
         const finalFile = await compressImage(imageFile);
-        const reader = new FileReader();
-        imageUrl = await new Promise((resolve, reject) => {
-          reader.onload = () => resolve(reader.result);
-          reader.onerror = reject;
-          reader.readAsDataURL(finalFile);
-        });
+        const formData = new FormData();
+        formData.append('image', finalFile);
+        const uploadRes = await apiPostFormData('/api/upload-image', formData);
+        imageUrl = uploadRes.url;
       }
 
       const imageUrls = [


### PR DESCRIPTION
## Summary
- serve `/uploads` folder and register new image upload route
- send uploaded book cover images to server and store returned URLs
- add upload router with multer to persist files on disk

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68934c2de7808323bd1e6e63a285dbef