### PR TITLE
Remove free shipping promotion above ₪250

### DIFF
--- a/src/components/BookDetails.jsx
+++ b/src/components/BookDetails.jsx
@@ -98,11 +98,7 @@ export default function BookDetails() {
             </button>
 
             {/* Benefits */}
-            <div className="grid grid-cols-3 gap-4 pt-6 border-t">
-              <div className="text-center">
-                <Package className="mx-auto text-[#112a55] mb-2" size={24} />
-                <span className="text-sm">משלוח חינם</span>
-              </div>
+            <div className="grid grid-cols-2 gap-4 pt-6 border-t">
               <div className="text-center">
                 <Clock className="mx-auto text-[#112a55] mb-2" size={24} />
                 <span className="text-sm">משלוח מהיר</span>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -39,8 +39,7 @@ export default function Header() {
           <Link to="/contact" className="hover:text-[#a48327] transition">יצירת קשר</Link>
         </nav>
         <div className="flex items-center gap-4">
-          <span className="text-xs">משלוח חינם בקנייה מעל 250 ₪</span>
-          <span className="text-xs border-r pr-4">הנחת מזומן 10%</span>
+          <span className="text-xs">הנחת מזומן 10%</span>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Remove banner offering free shipping on orders above ₪250
- Drop "free shipping" perk from book details

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893ab6cd62c8323bd563549719a6379