### PR TITLE
Add default shipping price settings

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,7 @@ import categoriesRouter from './router/categories.js';
 import ordersRouter from './router/orders.js';
 import wishlistRouter from './router/wishlist.js';
 import contentRouter from './router/content.js';
+import settingsRouter from './router/settings.js';
 import setupRouter from './router/setup.js';
 
 dotenv.config();
@@ -44,6 +45,7 @@ app.use(categoriesRouter);
 app.use(ordersRouter);
 app.use(wishlistRouter);
 app.use(contentRouter);
+app.use(settingsRouter);
 app.use(setupRouter);
 
 const PORT = process.env.PORT || 3000;

--- a/server/router/settings.js
+++ b/server/router/settings.js
@@ -1,0 +1,33 @@
+import express from 'express';
+import pool from '../db.js';
+
+const router = express.Router();
+
+router.get('/api/settings/:key', async (req, res) => {
+  try {
+    const { key } = req.params;
+    const { rows } = await pool.query('SELECT value FROM settings WHERE key=$1', [key]);
+    if (rows.length === 0) return res.json(null);
+    res.json(rows[0].value);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+router.post('/api/settings/:key', async (req, res) => {
+  try {
+    const { key } = req.params;
+    const { value } = req.body;
+    await pool.query(
+      'INSERT INTO settings(key, value) VALUES ($1,$2) ON CONFLICT(key) DO UPDATE SET value = EXCLUDED.value',
+      [key, value]
+    );
+    res.json({ success: true });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
+export default router;

--- a/src/pages/admin/Settings.jsx
+++ b/src/pages/admin/Settings.jsx
@@ -1,8 +1,16 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { apiPost } from '../../lib/apiClient';
+import useSettingsStore from '../../store/settingsStore';
 
 export default function Settings() {
   const [status, setStatus] = useState('');
+  const [shippingPrice, setShippingPrice] = useState('');
+  const [shippingStatus, setShippingStatus] = useState('');
+  const { getSetting, updateSetting } = useSettingsStore();
+
+  useEffect(() => {
+    getSetting('default_shipping_price').then((val) => setShippingPrice(val || ''));
+  }, [getSetting]);
 
   const handleSetup = async () => {
     try {
@@ -13,6 +21,11 @@ export default function Settings() {
       console.error('Setup error:', err);
       setStatus('error');
     }
+  };
+
+  const handleSaveShipping = async () => {
+    const result = await updateSetting('default_shipping_price', shippingPrice);
+    setShippingStatus(result.success ? 'saved' : 'error');
   };
 
   return (
@@ -31,6 +44,31 @@ export default function Settings() {
       {status === 'error' && (
         <p className="mt-4 text-red-600">שגיאה ביצירת הטבלאות</p>
       )}
+
+      <div className="mt-8">
+        <h2 className="text-xl font-semibold mb-4">הגדרות משלוח</h2>
+        <div className="flex items-center space-x-4">
+          <input
+            type="number"
+            className="border rounded px-3 py-2 w-40"
+            value={shippingPrice}
+            onChange={(e) => setShippingPrice(e.target.value)}
+            placeholder="מחיר משלוח"
+          />
+          <button
+            onClick={handleSaveShipping}
+            className="bg-[#a48327] text-white px-4 py-2 rounded hover:bg-[#8b6f1f]"
+          >
+            שמור
+          </button>
+        </div>
+        {shippingStatus === 'saved' && (
+          <p className="text-green-600 mt-2">נשמר בהצלחה</p>
+        )}
+        {shippingStatus === 'error' && (
+          <p className="text-red-600 mt-2">שגיאה בשמירה</p>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/store/settingsStore.js
+++ b/src/store/settingsStore.js
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+import { apiGet, apiPost } from '../lib/apiClient';
+
+const useSettingsStore = create((set, get) => ({
+  values: {},
+  getSetting: async (key) => {
+    if (get().values[key] !== undefined) return get().values[key];
+    try {
+      const value = await apiGet(`/api/settings/${key}`);
+      set(state => ({ values: { ...state.values, [key]: value } }));
+      return value;
+    } catch (error) {
+      console.error('Error loading setting:', error);
+      return null;
+    }
+  },
+  updateSetting: async (key, value) => {
+    try {
+      await apiPost(`/api/settings/${key}`, { value });
+      set(state => ({ values: { ...state.values, [key]: value } }));
+      return { success: true };
+    } catch (error) {
+      console.error('Error updating setting:', error);
+      return { success: false, error };
+    }
+  }
+}));
+
+export default useSettingsStore;


### PR DESCRIPTION
## Summary
- allow storing and retrieving app settings via new server router
- add Zustand store and admin UI for default shipping price

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6893ab9cf2c48323bd4fcd65ea72d359