### PR TITLE
Handle book image analysis fetch errors

### DIFF
--- a/src/pages/admin/AddBook.jsx
+++ b/src/pages/admin/AddBook.jsx
@@ -82,7 +82,11 @@ export default function AddBook() {
         setStep(2);
       } catch (error) {
         console.error('Error analyzing image:', error);
-        alert(`שגיאה בזיהוי הספר: ${error.message || error}. אנא נסה שוב או הזן את הפרטים ידנית.`);
+        const message =
+          error?.message === 'Failed to fetch'
+            ? 'שגיאה בזיהוי הספר: לא ניתן להתחבר לשרת. אנא נסה שוב או הזן את הפרטים ידנית.'
+            : `שגיאה בזיהוי הספר: ${error.message || error}. אנא נסה שוב או הזן את הפרטים ידנית.`;
+        alert(message);
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
## Summary
- Provide clearer error messaging when analyzing book cover images fails to reach the server

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689478c0b2788323acb35b18f10c2462