### PR TITLE
Compress product images over 500kb

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ npm run server
 
 The server reads the environment variables above and listens on `PORT`.
 
+### Image Uploads
+
+The `/api/upload-image` endpoint now enforces a 500 KB limit per image. Files
+that exceed this size are automatically compressed on the server until they are
+below the threshold. Each upload records the original and final size in
+`server.log` for auditing.
+
 ### Initializing the Database
 
 To create the tables required by the API (books, categories and other admin features) run:
@@ -79,6 +86,12 @@ npm run preview
 ```
 
 This serves the content of the `dist` directory on the port configured in `vite.config.js` (defaults to `3000`).
+
+### העלאת תמונות מוצרים
+
+נקודת הקצה `/api/upload-image` בשרת בודקת אם קובץ התמונה גדול מ‑500KB.
+קבצים החורגים מהגבלה מכווצים אוטומטית עד שמתחת לסף זה. פרטי ההעלאה
+נרשמים בקובץ `server.log` לצורכי תיעוד.
 
 ## הוראות בעברית
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "nodemailer": "^6.9.11",
     "openai": "^4.0.0",
     "pg": "^8.11.1",
+    "sharp": "^0.33.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.0",

--- a/server/logger.js
+++ b/server/logger.js
@@ -10,3 +10,11 @@ export function logError(err) {
   });
   console.error(err);
 }
+
+export function logInfo(message) {
+  const entry = `[${new Date().toISOString()}] ${message}\n`;
+  fs.appendFile(logFile, entry, (e) => {
+    if (e) console.error('Failed to write log:', e);
+  });
+  console.log(message);
+}

--- a/server/router/upload.js
+++ b/server/router/upload.js
@@ -2,6 +2,8 @@ import express from 'express';
 import multer from 'multer';
 import path from 'path';
 import fs from 'fs';
+import sharp from 'sharp';
+import { logInfo, logError } from '../logger.js';
 
 const router = express.Router();
 const uploadDir = path.join(process.cwd(), 'uploads');
@@ -18,10 +20,43 @@ const storage = multer.diskStorage({
 
 const upload = multer({ storage });
 
-router.post('/api/upload-image', upload.single('image'), (req, res) => {
+router.post('/api/upload-image', upload.single('image'), async (req, res) => {
   if (!req.file) {
     return res.status(400).json({ error: 'No file uploaded' });
   }
+
+  const filePath = req.file.path;
+  const originalSize = fs.statSync(filePath).size;
+  let finalPath = filePath;
+  let finalSize = originalSize;
+
+  try {
+    if (originalSize > 500 * 1024) {
+      let quality = 80;
+      let buffer = await sharp(filePath).jpeg({ quality }).toBuffer();
+      while (buffer.length > 500 * 1024 && quality > 30) {
+        quality -= 10;
+        buffer = await sharp(filePath).jpeg({ quality }).toBuffer();
+      }
+      finalSize = buffer.length;
+
+      const newFilename = `${path.parse(req.file.filename).name}.jpg`;
+      finalPath = path.join(uploadDir, newFilename);
+      await fs.promises.writeFile(finalPath, buffer);
+      if (finalPath !== filePath) {
+        await fs.promises.unlink(filePath);
+      }
+      req.file.filename = newFilename;
+    }
+  } catch (err) {
+    logError(err);
+    return res.status(500).json({ error: 'Image processing failed' });
+  }
+
+  logInfo(
+    `Uploaded image ${req.file.filename}: ${Math.round(originalSize / 1024)}kb -> ${Math.round(finalSize / 1024)}kb`
+  );
+
   const url = `/uploads/${req.file.filename}`;
   res.json({ url });
 });


### PR DESCRIPTION
## Summary
- compress uploaded images over 500kb using sharp and log the size reduction
- add logInfo helper to write informational entries to server.log
- document automatic image compression for product uploads

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68947b8a86848323a5a7de5905f7e66a