### PR TITLE
Handle image-analysis failure in AddBook form

### DIFF
--- a/src/pages/admin/AddBook.jsx
+++ b/src/pages/admin/AddBook.jsx
@@ -87,6 +87,7 @@ export default function AddBook() {
             ? 'שגיאה בזיהוי הספר: לא ניתן להתחבר לשרת. אנא נסה שוב או הזן את הפרטים ידנית.'
             : `שגיאה בזיהוי הספר: ${error.message || error}. אנא נסה שוב או הזן את הפרטים ידנית.`;
         alert(message);
+        setStep(2);
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
## Summary
- allow AddBook form to proceed when image analysis fails by moving to step 2 after showing error

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894be68ece88323980987b330d44ba4