### PR TITLE
Add admin image upload page

### DIFF
--- a/src/admin.jsx
+++ b/src/admin.jsx
@@ -10,6 +10,7 @@ import EmailPreview from './pages/admin/EmailPreview'
 import AddBook from './pages/admin/AddBook'
 import Categories from './pages/admin/Categories'
 import Settings from './pages/admin/Settings'
+import UploadImages from './pages/admin/UploadImages'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
@@ -24,6 +25,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
         <Route path="/admin/reports" element={<Reports />} />
         <Route path="/admin/email-preview" element={<EmailPreview />} />
         <Route path="/admin/settings" element={<Settings />} />
+        <Route path="/admin/upload-images" element={<UploadImages />} />
       </Routes>
     </Router>
   </React.StrictMode>,

--- a/src/pages/admin/Dashboard.jsx
+++ b/src/pages/admin/Dashboard.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import { Users, Package, CreditCard, BarChart2, Tag, Settings, Mail, FolderTree } from 'lucide-react';
+import { Users, Package, CreditCard, BarChart2, Tag, Settings, Mail, FolderTree, Upload } from 'lucide-react';
 
 const menuItems = [
   {
@@ -26,6 +26,12 @@ const menuItems = [
     icon: FolderTree,
     link: '/admin/categories',
     description: 'ניהול קטגוריות וקטגוריות משנה'
+  },
+  {
+    title: 'העלאת תמונות',
+    icon: Upload,
+    link: '/admin/upload-images',
+    description: 'העלאת תמונות של מוצרים וספרים'
   },
   {
     title: 'מבצעים והנחות',

--- a/src/pages/admin/UploadImages.jsx
+++ b/src/pages/admin/UploadImages.jsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { Upload, Loader } from 'lucide-react';
+import { apiPostFormData } from '../../lib/apiClient';
+
+export default function UploadImages() {
+  const [files, setFiles] = useState([]);
+  const [uploadedUrls, setUploadedUrls] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const handleFilesChange = (e) => {
+    setFiles(Array.from(e.target.files));
+  };
+
+  const handleUpload = async () => {
+    if (!files.length) return;
+    setLoading(true);
+    const urls = [];
+    try {
+      for (const file of files) {
+        const formData = new FormData();
+        formData.append('image', file);
+        const res = await apiPostFormData('/api/upload-image', formData);
+        if (res.url) urls.push(res.url);
+        if (res.urls) urls.push(...res.urls);
+      }
+      setUploadedUrls(urls);
+    } catch (err) {
+      console.error('Error uploading image:', err);
+      alert('שגיאה בהעלאת התמונה');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-8">
+      <h1 className="text-3xl font-bold text-[#112a55] mb-8">העלאת תמונות</h1>
+      <div className="bg-white rounded-xl p-6 shadow-lg">
+        <input
+          type="file"
+          multiple
+          onChange={handleFilesChange}
+          className="mb-4"
+          accept="image/*,.zip"
+        />
+        <button
+          onClick={handleUpload}
+          disabled={loading || files.length === 0}
+          className="bg-[#a48327] text-white px-4 py-2 rounded-md hover:bg-[#916f22] disabled:opacity-50 flex items-center gap-2"
+        >
+          {loading ? <Loader className="animate-spin" size={20} /> : <Upload size={20} />}
+          העלאה
+        </button>
+      </div>
+      {uploadedUrls.length > 0 && (
+        <div className="mt-6">
+          <h2 className="text-xl font-semibold mb-2">קישורים לתמונות:</h2>
+          <ul className="list-disc pr-5 text-[#112a55]">
+            {uploadedUrls.map(url => (
+              <li key={url}>
+                <a href={url} target="_blank" rel="noopener noreferrer" className="text-blue-600 underline">
+                  {url}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add UploadImages admin page for uploading product and book images
- link new upload page from admin router and dashboard menu

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6894ee6d92908323bdb87c56a5bca784