### PR TITLE
Serve admin routes from server

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -53,6 +53,17 @@ app.use(settingsRouter);
 app.use(setupRouter);
 app.use(uploadRouter);
 
+const distPath = path.join(process.cwd(), 'dist');
+app.use(express.static(distPath));
+
+app.get('/admin/*', (req, res) => {
+  res.sendFile(path.join(distPath, 'admin.html'));
+});
+
+app.get('*', (req, res) => {
+  res.sendFile(path.join(distPath, 'index.html'));
+});
+
 const PORT = process.env.PORT || 3000;
 
 async function ensureImageUrlsColumn() {


### PR DESCRIPTION
## Summary
- Serve built frontend assets from Express
- Add explicit `/admin/*` and catch-all routes to return SPA entry points

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6894f958317c8323a392daa85d279864