### PR TITLE
Fix admin route 404 for nested pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 uploads/
+dist/

--- a/server/index.js
+++ b/server/index.js
@@ -56,10 +56,12 @@ app.use(uploadRouter);
 const distPath = path.join(process.cwd(), 'dist');
 app.use(express.static(distPath));
 
-app.get('/admin/*', (req, res) => {
+// Serve the admin SPA for both /admin and any nested admin routes
+app.get(['/admin', '/admin/*'], (req, res) => {
   res.sendFile(path.join(distPath, 'admin.html'));
 });
 
+// Fallback to the main client for all other routes
 app.get('*', (req, res) => {
   res.sendFile(path.join(distPath, 'index.html'));
 });


### PR DESCRIPTION
## Summary
- Serve the admin SPA for `/admin` and all nested routes
- Ignore `dist/` build output

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895042dd9348323ba2e9952c1f26a36