### PR TITLE
Enable React Router v7 future flags and improve upload error feedback

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -35,7 +35,7 @@ function App() {
   }, [initAuth, initCart]);
 
   return (
-    <Router>
+    <Router future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <div dir="rtl" className="font-serif bg-[#f8f6f1] min-h-screen">
         <Header />
         <main className="max-w-7xl mx-auto px-4 py-8">

--- a/src/admin.jsx
+++ b/src/admin.jsx
@@ -14,7 +14,7 @@ import UploadImages from './pages/admin/UploadImages'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <Router>
+    <Router future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <Routes>
         <Route path="/" element={<Dashboard />} />
         <Route path="/admin" element={<Dashboard />} />

--- a/src/pages/admin/UploadImages.jsx
+++ b/src/pages/admin/UploadImages.jsx
@@ -26,7 +26,8 @@ export default function UploadImages() {
       setUploadedUrls(urls);
     } catch (err) {
       console.error('Error uploading image:', err);
-      alert('שגיאה בהעלאת התמונה');
+      const message = err?.message || 'שגיאה בהעלאת התמונה';
+      alert(message);
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- Opt in to React Router v7 `startTransition` and `relativeSplatPath` future flags to eliminate deprecation warnings
- Surface server error messages when uploading images in the admin dashboard

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6895090fc8f0832392330997659fe279