### PR TITLE
Handle empty error responses in API client

### DIFF
--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -8,7 +8,8 @@ async function handleResponse(res) {
     message = data.error || JSON.stringify(data);
   } catch (_) {
     try {
-      message = await res.text();
+      const text = await res.text();
+      if (text) message = text;
     } catch (e) {
       // ignore
     }


### PR DESCRIPTION
## Summary
- Avoid overwriting default error message with empty response text

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68950a82d8f083239dcff2a8b6270937