### PR TITLE
Handle additional ZIP MIME types in upload route

### DIFF
--- a/server/router/upload.js
+++ b/server/router/upload.js
@@ -29,7 +29,12 @@ router.post('/api/upload-image', upload.single('image'), async (req, res) => {
   }
 
   const filePath = req.file.path;
-  const isZip = req.file.mimetype === 'application/zip';
+  // Some browsers report ZIP uploads with different MIME types
+  const zipMimeTypes = [
+    'application/zip',
+    'application/x-zip-compressed'
+  ];
+  const isZip = zipMimeTypes.includes(req.file.mimetype);
 
   // Handle ZIP files: extract images and return list of URLs
   if (isZip) {


### PR DESCRIPTION
## Summary
- broaden ZIP MIME type detection so uploaded archives are processed correctly

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689509e1ab148323828c379f71ed6f33