### PR TITLE
Support additional ZIP mime types for image upload

### DIFF
--- a/server/router/upload.js
+++ b/server/router/upload.js
@@ -29,7 +29,9 @@ router.post('/api/upload-image', upload.single('image'), async (req, res) => {
   }
 
   const filePath = req.file.path;
-  const isZip = req.file.mimetype === 'application/zip';
+  const isZip = ['application/zip', 'application/x-zip-compressed'].includes(
+    req.file.mimetype
+  );
 
   // Handle ZIP files: extract images and return list of URLs
   if (isZip) {


### PR DESCRIPTION
## Summary
- Treat `application/x-zip-compressed` files as ZIP archives in the upload endpoint

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689511d3397483238a2571965e5c6c23