### PR TITLE
Ensure uploaded image links use consistent base URL

### DIFF
--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -1,4 +1,4 @@
-const API_URL = import.meta.env.VITE_API_URL || '';
+export const API_URL = import.meta.env.VITE_API_URL || '';
 
 async function handleResponse(res) {
   if (res.ok) return res.json();

--- a/src/pages/admin/AddBook.jsx
+++ b/src/pages/admin/AddBook.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Upload, ArrowRight, Loader, Plus } from 'lucide-react';
 import { useSearchParams } from 'react-router-dom';
-import { apiPostFormData } from '../../lib/apiClient';
+import { apiPostFormData, API_URL } from '../../lib/apiClient';
 import { compressImage } from '../../lib/imageUtils';
 import useCategoriesStore from '../../store/categoriesStore';
 import useBooksStore from '../../store/booksStore';
@@ -72,13 +72,14 @@ export default function AddBook() {
       const uploadRes = await apiPostFormData('/api/upload-image', formData);
 
       if (uploadRes.urls) {
-        setZipUrls(uploadRes.urls);
+        setZipUrls(uploadRes.urls.map(u => `${API_URL}${u}`));
         setStep(2);
       } else if (uploadRes.url) {
-        const resp = await fetch(uploadRes.url);
+        const fullUrl = `${API_URL}${uploadRes.url}`;
+        const resp = await fetch(fullUrl);
         const blob = await resp.blob();
         const selectedFile = new File([blob], 'image.jpg', { type: blob.type });
-        await processSelectedFile(selectedFile, uploadRes.url);
+        await processSelectedFile(selectedFile, fullUrl);
       }
     } catch (err) {
       console.error('Error uploading image:', err);
@@ -160,7 +161,7 @@ export default function AddBook() {
         const formData = new FormData();
         formData.append('image', finalFile);
         const uploadRes = await apiPostFormData('/api/upload-image', formData);
-        imageUrl = uploadRes.url;
+        imageUrl = `${API_URL}${uploadRes.url}`;
       }
 
       const imageUrls = [

--- a/src/pages/admin/UploadImages.jsx
+++ b/src/pages/admin/UploadImages.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Upload, Loader } from 'lucide-react';
-import { apiPostFormData } from '../../lib/apiClient';
+import { apiPostFormData, API_URL } from '../../lib/apiClient';
 
 export default function UploadImages() {
   const [files, setFiles] = useState([]);
@@ -20,8 +20,8 @@ export default function UploadImages() {
         const formData = new FormData();
         formData.append('image', file);
         const res = await apiPostFormData('/api/upload-image', formData);
-        if (res.url) urls.push(res.url);
-        if (res.urls) urls.push(...res.urls);
+        if (res.url) urls.push(`${API_URL}${res.url}`);
+        if (res.urls) urls.push(...res.urls.map(u => `${API_URL}${u}`));
       }
       setUploadedUrls(urls);
     } catch (err) {


### PR DESCRIPTION
## Summary
- Export `API_URL` from API client for reuse across components
- Prefix image upload responses with `API_URL` in admin UploadImages page
- Use `API_URL` for uploaded image links in admin AddBook flow

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68951275f5b083238b62c6fdb01b84f9