### PR TITLE
Remove image upload size limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,11 @@ The server reads the environment variables above and listens on `PORT`.
 
 ### Image Uploads
 
-The `/api/upload-image` endpoint now enforces a 300 KB limit per image. Files
-that exceed this size are automatically compressed on the server until they are
-below the threshold. The endpoint also accepts a ZIP file of images, extracts
-them and returns URLs for each extracted image so you can choose the desired
-cover. Each upload records the original and final size in `server.log` for
-auditing.
+The `/api/upload-image` endpoint accepts individual images or a ZIP file of
+images. Uploaded files are stored on the server, and when a ZIP is uploaded the
+images are extracted and URLs are returned for each file so you can choose the
+desired cover. Each upload records the original and final size in `server.log`
+for auditing.
 
 ### Initializing the Database
 
@@ -91,10 +90,10 @@ This serves the content of the `dist` directory on the port configured in `vite.
 
 ### העלאת תמונות מוצרים
 
-נקודת הקצה `/api/upload-image` בשרת בודקת אם קובץ התמונה גדול מ‑300KB.
-קבצים החורגים מהגבלה מכווצים אוטומטית עד שמתחת לסף זה. ניתן גם להעלות קובץ
-ZIP של תמונות, הקבצים יחולצו ויוחזרו קישורים לכל תמונה לבחירתכם. פרטי ההעלאה
-נרשמים בקובץ `server.log` לצורכי תיעוד.
+נקודת הקצה `/api/upload-image` בשרת מקבלת קובצי תמונה בודדים או קובץ ZIP של
+תמונות. הקבצים נשמרים בשרת, ואם הועלה קובץ ZIP התמונות יחולצו ויוחזרו
+קישורים לכל תמונה לבחירתכם. פרטי ההעלאה נרשמים בקובץ `server.log` לצורכי
+תיעוד.
 
 ## הוראות בעברית
 


### PR DESCRIPTION
## Summary
- Remove 300KB size restriction from `/api/upload-image` by always converting uploads to JPEG without enforcing a limit
- Update documentation to reflect unlimited image upload sizes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689533b2b96c83239aeb52f6f5ea114f