### PR TITLE
fix: default API URL to origin

### DIFF
--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -1,4 +1,10 @@
-export const API_URL = import.meta.env.VITE_API_URL || '';
+const origin =
+  typeof window !== 'undefined' ? window.location.origin : '';
+const DEFAULT_API_URL = origin.startsWith('http')
+  ? origin
+  : 'http://localhost:3000';
+
+export const API_URL = import.meta.env.VITE_API_URL || DEFAULT_API_URL;
 
 async function handleResponse(res) {
   if (res.ok) return res.json();


### PR DESCRIPTION
## Summary
- provide default API base URL using window location or localhost fallback

## Testing
- `npm test` *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_e_689535a9418883239aad2b1c386ae956