### PR TITLE
Handle /admin and /admin/ paths

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -56,7 +56,7 @@ app.use(uploadRouter);
 const distPath = path.join(process.cwd(), 'dist');
 app.use(express.static(distPath));
 
-app.get('/admin/*', (req, res) => {
+app.get('/admin*', (req, res) => {
   res.sendFile(path.join(distPath, 'admin.html'));
 });
 


### PR DESCRIPTION
## Summary
- Serve the admin dashboard for `/admin` by matching any path starting with `/admin`

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897bcf6c4dc83239467b6875e48e05a