### PR TITLE
Handle null AI responses in AddBook

### DIFF
--- a/src/pages/admin/AddBook.jsx
+++ b/src/pages/admin/AddBook.jsx
@@ -111,14 +111,19 @@ export default function AddBook() {
         const aiResponse = await apiPostFormData('/api/analyze-book-image', formData);
         console.log('AI response', aiResponse);
 
-        setAiData(aiResponse);
-        setBookData(prev => ({
-          ...prev,
-          title: aiResponse.title || '',
-          author: aiResponse.author || '',
-          description: aiResponse.description || '',
-          isbn: aiResponse.isbn || ''
-        }));
+        if (aiResponse && typeof aiResponse === 'object') {
+          setAiData(aiResponse);
+          setBookData(prev => ({
+            ...prev,
+            title: aiResponse.title || '',
+            author: aiResponse.author || '',
+            description: aiResponse.description || '',
+            isbn: aiResponse.isbn || ''
+          }));
+        } else {
+          console.warn('Invalid AI response:', aiResponse);
+          alert('שגיאה בזיהוי הספר: לא התקבלו נתונים. אנא הזן את הפרטים ידנית.');
+        }
 
         setStep(3);
       } catch (error) {


### PR DESCRIPTION
## Summary
- Safeguard AddBook from crashing when AI response is null
- Warn the user and allow manual entry when AI analysis returns no data

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897c0c5a3b483239fc82c12a05bae22