### PR TITLE
Handle invalid AI response in AddBook

### DIFF
--- a/src/pages/admin/AddBook.jsx
+++ b/src/pages/admin/AddBook.jsx
@@ -108,18 +108,36 @@ export default function AddBook() {
         const formData = new FormData();
         formData.append('image', processedFile);
 
-        const aiResponse = await apiPostFormData('/api/analyze-book-image', formData);
+        let aiResponse = await apiPostFormData(
+          '/api/analyze-book-image',
+          formData
+        );
         console.log('AI response', aiResponse);
 
-        if (aiResponse && typeof aiResponse === 'object') {
-          setAiData(aiResponse);
-          setBookData(prev => ({
-            ...prev,
-            title: aiResponse.title || '',
-            author: aiResponse.author || '',
-            description: aiResponse.description || '',
-            isbn: aiResponse.isbn || ''
-          }));
+        if (typeof aiResponse === 'string') {
+          try {
+            aiResponse = JSON.parse(aiResponse);
+          } catch {
+            aiResponse = null;
+          }
+        }
+
+        if (aiResponse && typeof aiResponse === 'object' && !Array.isArray(aiResponse)) {
+          if (aiResponse.error) {
+            console.warn('AI analysis error:', aiResponse.error);
+            alert(
+              `שגיאה בזיהוי הספר: ${aiResponse.error}. אנא הזן את הפרטים ידנית.`
+            );
+          } else {
+            setAiData(aiResponse);
+            setBookData(prev => ({
+              ...prev,
+              title: aiResponse.title || '',
+              author: aiResponse.author || '',
+              description: aiResponse.description || '',
+              isbn: aiResponse.isbn || ''
+            }));
+          }
         } else {
           console.warn('Invalid AI response:', aiResponse);
           alert('שגיאה בזיהוי הספר: לא התקבלו נתונים. אנא הזן את הפרטים ידנית.');


### PR DESCRIPTION
## Summary
- Safely handle string or null responses from /api/analyze-book-image
- Provide clearer error messaging when AI analysis fails

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897c2965d6c8323b085cebc84febf98