### PR TITLE
fix: normalize URLs before compression

### DIFF
--- a/src/pages/admin/UploadImages.jsx
+++ b/src/pages/admin/UploadImages.jsx
@@ -65,7 +65,8 @@ export default function UploadImages() {
   const handleCompressSelected = async () => {
     if (selected.length === 0) return;
     try {
-      await apiPost('/api/images/compress', { urls: selected });
+      const urls = selected.map((url) => url.replace(API_URL, ''));
+      await apiPost('/api/images/compress', { urls });
       await fetchImages();
       setSelected([]);
     } catch (err) {


### PR DESCRIPTION
## Summary
- normalize selected image URLs before calling compression API to avoid server errors

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897c3c9500c83239738cb02d066b643