### PR TITLE
feat: suggest categories via AI analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ Create a `.env` file (you can copy `.env.example`) and set the following variabl
 - `DATABASE_URL` – PostgreSQL connection string used by the API server.
 - `PORT` – Port for the Express server (defaults to `3000` if not set).
 - `OPENAI_API_KEY` – API key with access to GPT‑4 Vision used to extract book
-  details directly from uploaded cover images. If omitted, the `/api/analyze-book-image`
-  endpoint will return a `503` response and book image analysis will be disabled.
+  details and suggested categories directly from uploaded cover images. If omitted,
+  the `/api/analyze-book-image` endpoint will return a `503` response and book image
+  analysis will be disabled.
 - `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASS` – SMTP credentials used to
   send confirmation emails after an order is placed. If these are not set,
   the server will skip sending emails.

--- a/server/router/analyze.js
+++ b/server/router/analyze.js
@@ -72,8 +72,8 @@ router.post(
             {
               type: 'text',
               text:
-                'Extract the book title, author, description and ISBN from this book cover. ' +
-                'Respond in JSON with keys "title", "author", "description", "isbn". ' +
+                'Extract the book title, author, description, ISBN and suggested categories from this book cover. ' +
+                'Respond in JSON with keys "title", "author", "description", "isbn", "categories" (an array of category names in Hebrew). ' +
                 'The description must be written in Hebrew only.',
             },
             {
@@ -92,9 +92,12 @@ router.post(
         temperature: 0,
         response_format: { type: 'json_object' },
       });
-      let metadata = { title: '', author: '', description: '', isbn: '' };
+      let metadata = { title: '', author: '', description: '', isbn: '', categories: [] };
       try {
         metadata = JSON.parse(chat.choices[0].message.content);
+        if (!Array.isArray(metadata.categories)) {
+          metadata.categories = [];
+        }
       } catch (e) {
         console.error('Failed to parse OpenAI response:', chat.choices[0].message.content);
       }

--- a/src/pages/admin/AddBook.jsx
+++ b/src/pages/admin/AddBook.jsx
@@ -42,6 +42,22 @@ export default function AddBook() {
       initCategories();
     }
   }, [mode, step, categories.length, initCategories]);
+
+  useEffect(() => {
+    if (aiData?.categories && categories.length > 0) {
+      const matched = categories
+        .filter(cat =>
+          aiData.categories.some(name =>
+            name.trim().toLowerCase() === cat.name.trim().toLowerCase()
+          )
+        )
+        .map(cat => cat.id);
+      if (matched.length > 0) {
+        setSelectedCategories(matched);
+        setFieldConfirmed(prev => ({ ...prev, categories: false }));
+      }
+    }
+  }, [aiData, categories]);
   const [bookData, setBookData] = useState({
     title: '',
     author: '',


### PR DESCRIPTION
## Summary
- extend image analysis endpoint to request AI-generated category suggestions
- auto-select matching categories in admin add-book page based on AI response
- document that AI cover analysis also returns suggested categories

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6897d13094d083238a38136eaa2533c8