### PR TITLE
Allow admin routes to match trailing slashes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -53,11 +53,11 @@ function App() {
             <Route path="/shipping" element={<Shipping />} />
             <Route path="/returns" element={<Returns />} />
             <Route path="/faq" element={<FAQ />} />
-            <Route path="/admin" element={<Dashboard />} />
-            <Route path="/admin/orders" element={<Orders />} />
-            <Route path="/admin/products" element={<Products />} />
-            <Route path="/admin/add-book" element={<AddBook />} />
-            <Route path="/admin/reports" element={<Reports />} />
+            <Route path="/admin/*" element={<Dashboard />} />
+            <Route path="/admin/orders/*" element={<Orders />} />
+            <Route path="/admin/products/*" element={<Products />} />
+            <Route path="/admin/add-book/*" element={<AddBook />} />
+            <Route path="/admin/reports/*" element={<Reports />} />
             <Route path="*" element={<NotFound />} />
           </Routes>
         </main>

--- a/src/admin.jsx
+++ b/src/admin.jsx
@@ -17,15 +17,15 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     <Router future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <Routes>
         <Route path="/" element={<Dashboard />} />
-        <Route path="/admin" element={<Dashboard />} />
-        <Route path="/admin/orders" element={<Orders />} />
-        <Route path="/admin/products" element={<Products />} />
-        <Route path="/admin/add-book" element={<AddBook />} />
-        <Route path="/admin/categories" element={<Categories />} />
-        <Route path="/admin/reports" element={<Reports />} />
-        <Route path="/admin/email-preview" element={<EmailPreview />} />
-        <Route path="/admin/settings" element={<Settings />} />
-        <Route path="/admin/upload-images" element={<UploadImages />} />
+        <Route path="/admin/*" element={<Dashboard />} />
+        <Route path="/admin/orders/*" element={<Orders />} />
+        <Route path="/admin/products/*" element={<Products />} />
+        <Route path="/admin/add-book/*" element={<AddBook />} />
+        <Route path="/admin/categories/*" element={<Categories />} />
+        <Route path="/admin/reports/*" element={<Reports />} />
+        <Route path="/admin/email-preview/*" element={<EmailPreview />} />
+        <Route path="/admin/settings/*" element={<Settings />} />
+        <Route path="/admin/upload-images/*" element={<UploadImages />} />
       </Routes>
     </Router>
   </React.StrictMode>,


### PR DESCRIPTION
## Summary
- ensure admin dashboard routes accept optional trailing slashes on the client

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897d2150f048323aadf06cad91b0ecb