### PR TITLE
fix: remove extraneous parenthesis in books store

### DIFF
--- a/src/store/booksStore.js
+++ b/src/store/booksStore.js
@@ -79,6 +79,7 @@ const useBooksStore = create((set) => {
       return { success: false, error };
     }
   }
-}));
+  };
+});
 
 export default useBooksStore;


### PR DESCRIPTION
## Summary
- fix syntax error in books store by removing extra parenthesis

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6897d76e98688323a79a6a1e02e72b7e