### PR TITLE
Add image management features

### DIFF
--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -50,3 +50,13 @@ export const apiPostFormData = async (path, formData) => {
   });
   return handleResponse(res);
 };
+
+export const apiDelete = async (path, body) => {
+  const res = await fetch(`${API_URL}${path}`, {
+    method: 'DELETE',
+    credentials: 'include',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+  return handleResponse(res);
+};

--- a/src/pages/admin/UploadImages.jsx
+++ b/src/pages/admin/UploadImages.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Upload, Loader } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
-import { apiPostFormData, apiGet, apiPost, API_URL } from '../../lib/apiClient';
+import { apiPostFormData, apiGet, apiPost, apiDelete, API_URL } from '../../lib/apiClient';
 
 export default function UploadImages() {
   const [files, setFiles] = useState([]);
@@ -18,12 +18,28 @@ export default function UploadImages() {
   const fetchImages = async () => {
     try {
       const res = await apiGet('/api/images');
-      const images = res.images.map((img) => ({
-        url: `${API_URL}${img.url}`,
-        path: img.url,
-        size: img.size
-      }));
-      setServerImages(images);
+      const images = res.images
+        .map((img) => ({
+          url: `${API_URL}${img.url}`,
+          path: img.url,
+          size: img.size,
+          createdAt: img.createdAt,
+          inUse: img.inUse,
+        }))
+        .sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+
+      const grouped = images.reduce((acc, img) => {
+        const date = img.createdAt.split('T')[0];
+        if (!acc[date]) acc[date] = [];
+        acc[date].push(img);
+        return acc;
+      }, {});
+
+      const groups = Object.entries(grouped)
+        .map(([date, imgs]) => ({ date, images: imgs }))
+        .sort((a, b) => new Date(b.date) - new Date(a.date));
+
+      setServerImages(groups);
     } catch (err) {
       console.error('Error fetching images:', err);
     }
@@ -65,13 +81,27 @@ export default function UploadImages() {
   const handleCompressSelected = async () => {
     if (selected.length === 0) return;
     try {
-      const urls = selected.map((url) => url.replace(API_URL, ''));
+      const urls = selected;
       await apiPost('/api/images/compress', { urls });
       await fetchImages();
       setSelected([]);
     } catch (err) {
       console.error('Error compressing images:', err);
       alert(err?.message || 'שגיאה בהקטנת התמונות');
+    }
+  };
+
+  const handleDeleteSelected = async () => {
+    if (selected.length === 0) return;
+    if (!window.confirm('האם למחוק את התמונות שנבחרו?')) return;
+    try {
+      const urls = selected;
+      await apiDelete('/api/images', { urls });
+      await fetchImages();
+      setSelected([]);
+    } catch (err) {
+      console.error('Error deleting images:', err);
+      alert(err?.message || 'שגיאה במחיקת התמונות');
     }
   };
 
@@ -117,39 +147,58 @@ export default function UploadImages() {
       {serverImages.length > 0 && (
         <div className="mt-8">
           <h2 className="text-xl font-semibold mb-4">כל התמונות בשרת:</h2>
-          <button
-            onClick={handleCompressSelected}
-            disabled={selected.length === 0}
-            className="mb-4 w-full sm:w-auto bg-[#a48327] text-white px-4 py-2 rounded-md hover:bg-[#916f22] disabled:opacity-50"
-          >
-            הקטן תמונות נבחרות
-          </button>
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
-            {serverImages.map((img) => (
-              <div key={img.path} className="border rounded overflow-hidden relative flex flex-col">
-                <input
-                  type="checkbox"
-                  className="absolute top-2 left-2"
-                  checked={selected.includes(img.path)}
-                  onChange={() => toggleSelect(img.path)}
-                />
-                <img
-                  src={img.url}
-                  alt="Uploaded"
-                  className="w-full h-32 object-cover"
-                />
-                <div className="p-1 text-xs text-center">
-                  {(img.size / 1024).toFixed(1)} KB
-                </div>
-                <button
-                  onClick={() => navigate(`/admin/add-book?mode=ai&image=${encodeURIComponent(img.url)}`)}
-                  className="bg-[#a48327] text-white text-xs py-1 hover:bg-[#916f22]"
-                >
-                  רישום חכם
-                </button>
-              </div>
-            ))}
+          <div className="flex flex-col sm:flex-row gap-2 mb-4">
+            <button
+              onClick={handleCompressSelected}
+              disabled={selected.length === 0}
+              className="w-full sm:w-auto bg-[#a48327] text-white px-4 py-2 rounded-md hover:bg-[#916f22] disabled:opacity-50"
+            >
+              הקטן תמונות נבחרות
+            </button>
+            <button
+              onClick={handleDeleteSelected}
+              disabled={selected.length === 0}
+              className="w-full sm:w-auto bg-red-600 text-white px-4 py-2 rounded-md hover:bg-red-700 disabled:opacity-50"
+            >
+              מחק תמונות נבחרות
+            </button>
           </div>
+          {serverImages.map((group) => (
+            <div key={group.date} className="mb-6">
+              <h3 className="text-lg font-semibold mb-2">{group.date}</h3>
+              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4">
+                {group.images.map((img) => (
+                  <div key={img.path} className="border rounded overflow-hidden relative flex flex-col">
+                    <input
+                      type="checkbox"
+                      className="absolute top-2 left-2"
+                      checked={selected.includes(img.path)}
+                      onChange={() => toggleSelect(img.path)}
+                    />
+                    {img.inUse && (
+                      <div className="absolute top-2 right-2 bg-green-500 text-white text-xs px-1 rounded">
+                        בשימוש
+                      </div>
+                    )}
+                    <img
+                      src={img.url}
+                      alt="Uploaded"
+                      className="w-full h-32 object-cover"
+                    />
+                    <div className="p-1 text-xs text-center">
+                      {(img.size / 1024).toFixed(1)} KB
+                    </div>
+                    <button
+                      onClick={() => navigate(`/admin/add-book?mode=ai&image=${encodeURIComponent(img.url)}`)}
+                      className="bg-[#a48327] text-white text-xs py-1 hover:bg-[#916f22]"
+                    >
+                      רישום חכם
+                    </button>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Group server images by upload date and show usage indicators
- Allow deleting selected images from server
- Support DELETE requests in API client and mark used images via database

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68986d5a497083238a460e16ff8ea28d