### PR TITLE
Align Save Book button to the right

### DIFF
--- a/src/pages/AdminBookManager.js
+++ b/src/pages/AdminBookManager.js
@@ -217,12 +217,14 @@ export default function AdminBookManager() {
           </div>
         </div>
 
-        <button
-          type="submit"
-          className="w-full bg-[#a48327] text-white py-2 rounded hover:bg-[#8b6f1f]"
-        >
-          {formData.id ? "עדכן ספר" : "שמור ספר"}
-        </button>
+        <div className="flex justify-end">
+          <button
+            type="submit"
+            className="bg-[#a48327] text-white py-2 px-4 rounded hover:bg-[#8b6f1f]"
+          >
+            {formData.id ? "עדכן ספר" : "שמור ספר"}
+          </button>
+        </div>
         {message && <div className="text-sm mt-2">{message}</div>}
       </form>
 


### PR DESCRIPTION
## Summary
- Right-align the Save Book button in the admin book manager form for clearer layout.

## Testing
- `npm test` *(fails: Missing script "test" )*

------
https://chatgpt.com/codex/tasks/task_e_6898a6a2258c8323bd12b8cbd7e72015