### PR TITLE
Gracefully handle unauthorized auth initialization

### DIFF
--- a/src/store/authStore.js
+++ b/src/store/authStore.js
@@ -19,12 +19,17 @@ const useAuthStore = create((set) => ({
         error: null
       });
     } catch (error) {
-      console.error('Error in auth initialization:', error);
-      set({
-        error: 'שגיאה בטעינת המשתמש',
-        loading: false,
-        user: null
-      });
+      if (error?.status === 401) {
+        console.log('No authenticated user found');
+        set({ user: null, loading: false, error: null });
+      } else {
+        console.error('Error in auth initialization:', error);
+        set({
+          error: 'שגיאה בטעינת המשתמש',
+          loading: false,
+          user: null
+        });
+      }
     }
   },
 


### PR DESCRIPTION
## Summary
- Avoid logging errors when auth initialization receives 401
- Set auth state to no user instead of error on unauthorized

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68991ea26f648323a95e59c3daafa6d4