### PR TITLE
Resize header logo to 7.5cm

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -49,7 +49,7 @@ export default function Header() {
             <img
               src="/logo.png"
               alt="ספרי קודש תלפיות"
-              className="h-48 object-contain"
+              className="object-contain h-[7.5cm]"
               style={{ filter: 'brightness(0.85)' }}
             />
             <p className="text-[#112a55] text-2xl font-bold tracking-wide" style={{ fontFamily: 'Frank Ruhl Libre, serif' }}>המקום המושלם לספרי קודש במחירים נוחים</p>


### PR DESCRIPTION
## Summary
- adjust header logo image to be exactly 7.5cm tall for consistent branding

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b45f64aac8323a5e71f4ad870fc86