### PR TITLE
Add shipping fee details and free shipping option in orders

### DIFF
--- a/server/router/orders.js
+++ b/server/router/orders.js
@@ -123,6 +123,25 @@ router.get('/api/admin/orders', async (_req, res) => {
   }
 });
 
+router.post('/api/admin/orders/:id/free-shipping', async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { rows } = await pool.query(
+      'UPDATE orders SET total = total - shipping_price, shipping_price = 0 WHERE id=$1 RETURNING *',
+      [id]
+    );
+
+    if (rows.length === 0) {
+      return res.status(404).json({ error: 'Order not found' });
+    }
+
+    res.json(rows[0]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Database error' });
+  }
+});
+
 router.post('/api/admin/orders/:id/status', async (req, res) => {
   try {
     const { id } = req.params;

--- a/src/components/PersonalOrders.jsx
+++ b/src/components/PersonalOrders.jsx
@@ -71,13 +71,23 @@ export default function PersonalOrders() {
                   </div>
                 ))}
               </div>
-              <div className="mt-4 flex justify-between items-center">
-                <span className="font-bold">סה"כ: {order.total} ₪</span>
-                <span
-                  className={`px-2 py-1 rounded text-sm ${order.status === 'completed' ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'}`}
-                >
-                  {order.status === 'completed' ? 'הושלם' : 'בטיפול'}
-                </span>
+              <div className="mt-4 space-y-1">
+                <div className="flex justify-between">
+                  <span>מחיר פריטים:</span>
+                  <span>{Number(order.total) - Number(order.shipping_price || 0)} ₪</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>דמי משלוח:</span>
+                  <span>{Number(order.shipping_price || 0)} ₪</span>
+                </div>
+                <div className="flex justify-between items-center">
+                  <span className="font-bold">סה"כ: {order.total} ₪</span>
+                  <span
+                    className={`px-2 py-1 rounded text-sm ${order.status === 'completed' ? 'bg-green-100 text-green-800' : 'bg-yellow-100 text-yellow-800'}`}
+                  >
+                    {order.status === 'completed' ? 'הושלם' : 'בטיפול'}
+                  </span>
+                </div>
               </div>
             </div>
           ))}

--- a/src/pages/admin/Orders.jsx
+++ b/src/pages/admin/Orders.jsx
@@ -32,6 +32,8 @@ export default function Orders() {
           email: o.email,
           phone: o.phone,
           total: Number(o.total),
+          shippingPrice: Number(o.shipping_price || 0),
+          itemsTotal: Number(o.total) - Number(o.shipping_price || 0),
           status: o.status,
           items: (o.order_items || []).map((item) => ({
             title: item.title,
@@ -167,7 +169,15 @@ export default function Orders() {
                 </div>
               </div>
 
-              <div className="border-t pt-4">
+              <div className="border-t pt-4 space-y-2">
+                <div className="flex justify-between">
+                  <span>מחיר פריטים</span>
+                  <span>{selectedOrder.itemsTotal} ₪</span>
+                </div>
+                <div className="flex justify-between">
+                  <span>דמי משלוח</span>
+                  <span>{selectedOrder.shippingPrice} ₪</span>
+                </div>
                 <div className="flex justify-between font-bold">
                   <span>סה"כ</span>
                   <span>{selectedOrder.total} ₪</span>
@@ -176,6 +186,35 @@ export default function Orders() {
 
               <div className="flex justify-end gap-4">
                 <button className="px-4 py-2 border rounded hover:bg-gray-50">הדפס</button>
+                {selectedOrder.shippingPrice > 0 && (
+                  <button
+                    onClick={() => {
+                      apiPost(`/api/admin/orders/${selectedOrder.id}/free-shipping`)
+                        .then(updated => {
+                          setOrders(prev => prev.map(o =>
+                            o.id === updated.id
+                              ? {
+                                  ...o,
+                                  total: Number(updated.total),
+                                  shippingPrice: Number(updated.shipping_price),
+                                  itemsTotal: Number(updated.total) - Number(updated.shipping_price),
+                                }
+                              : o
+                          ));
+                          setSelectedOrder(prev => ({
+                            ...prev,
+                            total: Number(updated.total),
+                            shippingPrice: Number(updated.shipping_price),
+                            itemsTotal: Number(updated.total) - Number(updated.shipping_price),
+                          }));
+                        })
+                        .catch(err => console.error('❌ שגיאה בעדכון משלוח:', err));
+                    }}
+                    className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+                  >
+                    הענק משלוח חינם
+                  </button>
+                )}
                 <select
                   value={statusUpdate}
                   onChange={(e) => setStatusUpdate(e.target.value)}


### PR DESCRIPTION
## Summary
- display item and shipping breakdown in admin order details
- allow admins to grant free shipping discounts via new endpoint
- show shipping fee breakdown in personal orders

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b551153fc83238532b27b8487c0fd