### PR TITLE
Set correct API client default URLs

### DIFF
--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -1,8 +1,9 @@
 const origin =
   typeof window !== 'undefined' ? window.location.origin : '';
-const DEFAULT_API_URL = origin.startsWith('http')
-  ? origin
-  : 'http://localhost:3000';
+const isLocal = origin.includes('localhost') || origin.includes('127.0.0.1');
+const DEFAULT_API_URL = isLocal
+  ? 'http://localhost:3000'
+  : 'https://api.talpiot-books.com';
 
 export const API_URL = import.meta.env.VITE_API_URL || DEFAULT_API_URL;
 


### PR DESCRIPTION
## Summary
- Use production API endpoint at https://api.talpiot-books.com when not running locally
- Keep localhost:3000 as the default backend for local development

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bb9c217948323be816d309979f60e