### PR TITLE
fix: correct local API base URL

### DIFF
--- a/src/lib/apiClient.js
+++ b/src/lib/apiClient.js
@@ -2,7 +2,7 @@ const origin =
   typeof window !== 'undefined' ? window.location.origin : '';
 const isLocal = origin.includes('localhost') || origin.includes('127.0.0.1');
 const DEFAULT_API_URL = isLocal
-  ? 'http://localhost:3000'
+  ? 'http://localhost:3001'
   : 'https://api.talpiot-books.com';
 
 export const API_URL = import.meta.env.VITE_API_URL || DEFAULT_API_URL;


### PR DESCRIPTION
## Summary
- point local API requests to port 3001 instead of 3000

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689bbd2999008323ab570c219dd287c1