### PR TITLE
feat: add cookie consent popup

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import Products from "./pages/admin/Products";
 import Reports from "./pages/admin/Reports";
 import AddBook from "./pages/admin/AddBook";
 import ShoppingCart from "./components/ShoppingCart";
+import CookieConsent from "./components/CookieConsent";
 import useAuthStore from "./store/authStore";
 import useCartStore from "./store/cartStore";
 import { Phone, Mail, Clock } from "lucide-react";
@@ -128,6 +129,7 @@ function App() {
           </div>
         </footer>
 
+        <CookieConsent />
         <ShoppingCart />
       </div>
     </Router>

--- a/src/components/CookieConsent.jsx
+++ b/src/components/CookieConsent.jsx
@@ -1,0 +1,33 @@
+import React, { useState, useEffect } from 'react';
+
+export default function CookieConsent() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const consent = localStorage.getItem('cookieConsent');
+    if (!consent) {
+      setVisible(true);
+    }
+  }, []);
+
+  const acceptCookies = () => {
+    localStorage.setItem('cookieConsent', 'true');
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="fixed bottom-4 left-4 right-4 md:right-auto md:max-w-sm bg-white p-4 rounded-lg shadow-lg z-40 flex items-center gap-4 animate-slide-up">
+      <p className="text-sm text-gray-700 flex-1">
+        אנו משתמשים בעוגיות כדי לשפר את חוויית הגלישה שלך.
+      </p>
+      <button
+        onClick={acceptCookies}
+        className="bg-[#a48327] text-white px-4 py-2 rounded-lg hover:bg-[#8b6f1f] transition-colors text-sm"
+      >
+        אישור
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- integrate CookieConsent component across the app
- implement a bottom cookie consent popup using localStorage

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689c767665ac83238f0f851afbcadd03