### PR TITLE
Redirect /admin to trailing slash

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -51,7 +51,11 @@ app.use(contactRouter);
 const distPath = path.join(process.cwd(), 'dist');
 app.use(express.static(distPath));
 
-app.get('/admin*', (req, res) => {
+app.get('/admin', (req, res) => {
+  res.redirect(301, '/admin/');
+});
+
+app.get('/admin/*', (req, res) => {
   res.sendFile(path.join(distPath, 'admin.html'));
 });
 


### PR DESCRIPTION
## Summary
- Redirect `/admin` requests to `/admin/` so assets resolve relative to trailing slash path

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689c783f585083238b41177ddaa4c08f