### PR TITLE
Fix admin free shipping action

### DIFF
--- a/src/pages/admin/Orders.jsx
+++ b/src/pages/admin/Orders.jsx
@@ -189,7 +189,7 @@ export default function Orders() {
                 {selectedOrder.shippingPrice > 0 && (
                   <button
                     onClick={() => {
-                      apiPost(`/api/admin/orders/${selectedOrder.id}/free-shipping`)
+                      apiPost(`/api/admin/orders/${selectedOrder.id}/free-shipping`, {})
                         .then(updated => {
                           setOrders(prev => prev.map(o =>
                             o.id === updated.id


### PR DESCRIPTION
## Summary
- Ensure the admin "free shipping" action sends a request body so Express can parse it

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cf2e548048323b5c327e03c4e50fa