### PR TITLE
Fix book update not saving due to id type mismatch

### DIFF
--- a/src/store/booksStore.js
+++ b/src/store/booksStore.js
@@ -54,10 +54,11 @@ const useBooksStore = create((set) => {
 
   updateBook: async (id, updatedBook) => {
     try {
-      const data = await apiPost(`/api/books/${id}`, updatedBook);
+      const numericId = Number(id);
+      const data = await apiPost(`/api/books/${numericId}`, updatedBook);
       set(state => ({
         books: state.books.map(book =>
-          book.id === id ? data : book
+          Number(book.id) === numericId ? data : book
         )
       }));
       return { success: true, data };
@@ -69,9 +70,10 @@ const useBooksStore = create((set) => {
 
   deleteBook: async (id) => {
     try {
-      await apiPost(`/api/books/${id}/delete`, {});
+      const numericId = Number(id);
+      await apiPost(`/api/books/${numericId}/delete`, {});
       set(state => ({
-        books: state.books.filter(book => book.id !== id)
+        books: state.books.filter(book => Number(book.id) !== numericId)
       }));
       return { success: true };
     } catch (error) {


### PR DESCRIPTION
## Summary
- normalize book IDs to numbers before updating/deleting to ensure state updates

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cfa3d04c883238dc16398ab3a3879