### PR TITLE
Prevent duplicate auth store initialization

### DIFF
--- a/src/store/authStore.js
+++ b/src/store/authStore.js
@@ -1,12 +1,16 @@
 import { create } from 'zustand';
 import { apiGet, apiPost } from '../lib/apiClient';
 
-const useAuthStore = create((set) => ({
+const useAuthStore = create((set, get) => ({
   user: null,
   loading: true,
   error: null,
-  
+  hasInitialized: false,
+
   initialize: async () => {
+    if (get().hasInitialized) return;
+    set({ hasInitialized: true });
+
     try {
       console.log('Initializing auth store...');
 


### PR DESCRIPTION
## Summary
- add hasInitialized flag in auth store to avoid repeated initialization calls
- guard initialize from running multiple times to stop duplicate logs

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d01209f5c8323b0ab4c1566de31c9