### PR TITLE
Add SEO tags to product detail pages

### DIFF
--- a/src/components/BookDetails.jsx
+++ b/src/components/BookDetails.jsx
@@ -54,6 +54,93 @@ export default function BookDetails() {
     fetchRelated();
   }, [book]);
 
+  useEffect(() => {
+    if (!book) return;
+
+    const previousTitle = document.title;
+    const descriptionTag =
+      document.querySelector('meta[name="description"]') ||
+      (() => {
+        const tag = document.createElement('meta');
+        tag.name = 'description';
+        document.head.appendChild(tag);
+        return tag;
+      })();
+    const previousDescription = descriptionTag.getAttribute('content');
+
+    const keywordsTag =
+      document.querySelector('meta[name="keywords"]') ||
+      (() => {
+        const tag = document.createElement('meta');
+        tag.name = 'keywords';
+        document.head.appendChild(tag);
+        return tag;
+      })();
+    const previousKeywords = keywordsTag.getAttribute('content');
+
+    const ogTitleTag =
+      document.querySelector('meta[property="og:title"]') ||
+      (() => {
+        const tag = document.createElement('meta');
+        tag.setAttribute('property', 'og:title');
+        document.head.appendChild(tag);
+        return tag;
+      })();
+    const previousOgTitle = ogTitleTag.getAttribute('content');
+
+    const ogDescriptionTag =
+      document.querySelector('meta[property="og:description"]') ||
+      (() => {
+        const tag = document.createElement('meta');
+        tag.setAttribute('property', 'og:description');
+        document.head.appendChild(tag);
+        return tag;
+      })();
+    const previousOgDescription = ogDescriptionTag.getAttribute('content');
+
+    const ogImageTag =
+      document.querySelector('meta[property="og:image"]') ||
+      (() => {
+        const tag = document.createElement('meta');
+        tag.setAttribute('property', 'og:image');
+        document.head.appendChild(tag);
+        return tag;
+      })();
+    const previousOgImage = ogImageTag.getAttribute('content');
+
+    const category = book.category || book.categories?.[0] || '';
+    const title = `${book.title}${category ? ' - ' + category : ''}`;
+
+    document.title = title;
+    descriptionTag.setAttribute('content', title);
+
+    const keywords = [book.title, ...(book.categories || [])].filter(Boolean);
+    keywordsTag.setAttribute('content', keywords.join(', '));
+
+    ogTitleTag.setAttribute('content', book.title);
+    ogDescriptionTag.setAttribute('content', title);
+    ogImageTag.setAttribute('content', book.image_urls?.[0] || book.image_url || '');
+
+    return () => {
+      document.title = previousTitle;
+      if (previousDescription !== null) {
+        descriptionTag.setAttribute('content', previousDescription);
+      }
+      if (previousKeywords !== null) {
+        keywordsTag.setAttribute('content', previousKeywords);
+      }
+      if (previousOgTitle !== null) {
+        ogTitleTag.setAttribute('content', previousOgTitle);
+      }
+      if (previousOgDescription !== null) {
+        ogDescriptionTag.setAttribute('content', previousOgDescription);
+      }
+      if (previousOgImage !== null) {
+        ogImageTag.setAttribute('content', previousOgImage);
+      }
+    };
+  }, [book]);
+
   if (loading) return <div className="text-center py-8">טוען...</div>;
   if (error) return <div className="text-center py-8 text-red-600">{error}</div>;
   if (!book) return <div className="text-center py-8">הספר לא נמצא</div>;


### PR DESCRIPTION
## Summary
- add dynamic SEO meta tags to book detail page using product and category data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*
- `npm install` *(fails: MaxListenersExceededWarning, appears to hang)*

------
https://chatgpt.com/codex/tasks/task_e_68a371a1cae48323a0b6fac1b74ba149