### PR TITLE
fix: single column manual book form

### DIFF
--- a/src/pages/admin/Products.jsx
+++ b/src/pages/admin/Products.jsx
@@ -393,7 +393,7 @@ export default function Products() {
             </h2>
             
             <form onSubmit={handleSubmit} className="space-y-4">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 gap-4">
                 <div>
                   <label className="block text-gray-700 mb-1">שם הספר *</label>
                   <input


### PR DESCRIPTION
## Summary
- show each book entry field on its own row in manual-add form

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a39e3161fc8323bebf5ef7b387a872