### PR TITLE
Log database query errors

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -7,8 +7,18 @@ dotenv.config();
 const { Pool } = pkg;
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
+// Log any unexpected errors emitted by the pool
 pool.on('error', (err) => {
   logError(err);
 });
+
+// Wrap the default query method so database errors are logged before
+// being propagated to callers
+const originalQuery = pool.query.bind(pool);
+pool.query = (...args) =>
+  originalQuery(...args).catch((err) => {
+    logError(err);
+    throw err;
+  });
 
 export default pool;


### PR DESCRIPTION
## Summary
- log unexpected pool errors and individual query failures to server.log

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad7663fb7c8323b526b2b53d585e99