### PR TITLE
Normalize admin image uploads and make additional images removable

### DIFF
--- a/src/lib/imageUtils.js
+++ b/src/lib/imageUtils.js
@@ -1,3 +1,5 @@
+import { API_URL } from './apiClient';
+
 export async function compressImage(file, maxSizeMB = 5) {
   if (!file) return file;
   if (file.size <= maxSizeMB * 1024 * 1024) {
@@ -54,4 +56,35 @@ export async function compressImage(file, maxSizeMB = 5) {
 
   // Fallback: return original file if compression failed
   return file;
+}
+
+export function normalizeApiImageUrl(url) {
+  if (!url) return '';
+  const trimmed = url.trim();
+  if (!trimmed) return '';
+
+  const base = API_URL.replace(/\/+$/, '');
+  if (trimmed.startsWith(base)) {
+    const relative = trimmed.slice(base.length);
+    if (!relative) return '/';
+    return relative.startsWith('/') ? relative : `/${relative}`;
+  }
+
+  return trimmed;
+}
+
+export function getAbsoluteImageUrl(url) {
+  if (!url) return '';
+  const trimmed = url.trim();
+  if (!trimmed) return '';
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    return trimmed;
+  }
+
+  const base = API_URL.replace(/\/+$/, '');
+  if (trimmed.startsWith('/')) {
+    return `${base}${trimmed}`;
+  }
+  return `${base}/${trimmed}`;
 }


### PR DESCRIPTION
## Summary
- add helper utilities to normalize API image URLs and compute absolute URLs on the client
- update the add-book and products admin flows to store relative URLs, preview images correctly, and let admins remove uploaded additional images
- ensure admin listings and modals resolve image paths consistently so extra images behave dynamically

## Testing
- npm install --ignore-scripts *(fails: 403 Forbidden fetching nodemailer)*

------
https://chatgpt.com/codex/tasks/task_e_68f53db2d2ec8323b53ecc435a64290b